### PR TITLE
Improve action logging UI and sandbox lifecycle

### DIFF
--- a/src/components/ActionLog.tsx
+++ b/src/components/ActionLog.tsx
@@ -1,0 +1,82 @@
+import type { ActionResult } from '../lib/types';
+
+const STATUS_LABELS: Record<Exclude<ActionResult['status'], undefined>, string> = {
+  pending: 'Pending',
+  success: 'Success',
+  error: 'Error',
+};
+
+const MAX_OUTPUT_LINES = 12;
+
+function getTargetLabel(action: ActionResult): string {
+  switch (action.type) {
+    case 'runCommand':
+      return action.command;
+    default:
+      return action.path;
+  }
+}
+
+function formatOutput(output: string | undefined) {
+  if (!output) return null;
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+  const lines = trimmed.split('\n');
+  const truncated = lines.slice(-MAX_OUTPUT_LINES);
+  const isTruncated = lines.length > truncated.length;
+  const formatted = truncated.join('\n');
+  return {
+    formatted: isTruncated ? `…\n${formatted}` : formatted,
+  };
+}
+
+interface ActionLogProps {
+  actions: ActionResult[];
+  heading?: string;
+  emptyState?: string;
+  compact?: boolean;
+  className?: string;
+}
+
+export function ActionLog({ actions, heading, emptyState, compact = false, className }: ActionLogProps) {
+  if (actions.length === 0 && !emptyState) {
+    return null;
+  }
+
+  const containerClassNames = ['action-log'];
+  if (compact) {
+    containerClassNames.push('compact');
+  }
+  if (className) {
+    containerClassNames.push(className);
+  }
+
+  return (
+    <div className={containerClassNames.join(' ')}>
+      {heading ? <h4>{heading}</h4> : null}
+      {actions.length === 0 ? (
+        <div className="action-log-empty">{emptyState}</div>
+      ) : (
+        actions.map((action, index) => {
+          const keyBase = `${action.type}-${index}-${getTargetLabel(action)}`;
+          const targetLabel = getTargetLabel(action);
+          const statusLabel = action.status ? STATUS_LABELS[action.status] : null;
+          const formattedOutput = action.type === 'runCommand' ? formatOutput(action.output) : null;
+
+          return (
+            <div key={keyBase} className="action-log-entry">
+              <div className="action-log-header">
+                <span className="badge">{action.type}</span>
+                {statusLabel ? <span className={`status-badge status-${action.status}`}>{statusLabel}</span> : null}
+              </div>
+              <div className="action-target">{targetLabel}</div>
+              {action.type === 'runCommand' && action.cwd ? <div className="action-meta">cwd: {action.cwd}</div> : null}
+              {action.message ? <div className="action-meta">{action.message}</div> : null}
+              {formattedOutput ? <pre className="action-output">{formattedOutput.formatted}</pre> : null}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from 'react';
 import type { ChatMessage, ActionResult } from '../lib/types';
+import { ActionLog } from './ActionLog';
 
 interface ChatPanelProps {
   messages: ChatMessage[];
@@ -30,18 +31,7 @@ export function ChatPanel({ messages, onSend, isProcessing, actionLog }: ChatPan
             <div key={message.id} className="chat-message">
               <div className="role">{message.role === 'assistant' ? 'Assistant' : 'You'}</div>
               <div>{message.content}</div>
-              {message.actions && message.actions.length > 0 ? (
-                <div className="action-log">
-                  {message.actions.map((action, index) => (
-                    <div key={`${action.type}-${index}`} className="action-log-entry">
-                      <span className="badge">{action.type}</span>
-                      <div>{'path' in action ? action.path : action.command}</div>
-                      {action.status ? <div>Status: {action.status}</div> : null}
-                      {action.message ? <div>{action.message}</div> : null}
-                    </div>
-                  ))}
-                </div>
-              ) : null}
+              {message.actions ? <ActionLog actions={message.actions} compact /> : null}
               {message.error ? <div className="action-log-entry">Error: {message.error}</div> : null}
             </div>
           ))}
@@ -57,18 +47,12 @@ export function ChatPanel({ messages, onSend, isProcessing, actionLog }: ChatPan
           </button>
         </form>
       </div>
-      <div className="action-log" style={{ marginLeft: '1rem', flex: '0 0 280px' }}>
-        <h4>Latest actions</h4>
-        {actionLog.length === 0 && <div>No actions executed yet.</div>}
-        {actionLog.map((action, index) => (
-          <div key={`${action.type}-${index}`} className="action-log-entry">
-            <strong>{action.type}</strong>
-            <div>{'path' in action ? action.path : action.command}</div>
-            {action.status ? <div>Status: {action.status}</div> : null}
-            {action.message ? <div>{action.message}</div> : null}
-          </div>
-        ))}
-      </div>
+      <ActionLog
+        actions={actionLog}
+        heading="Latest actions"
+        emptyState="No actions executed yet."
+        className="side-action-log"
+      />
     </div>
   );
 }

--- a/src/hooks/useWebContainer.ts
+++ b/src/hooks/useWebContainer.ts
@@ -210,6 +210,19 @@ export function useWebContainer() {
     void boot();
   }, [boot]);
 
+  useEffect(() => {
+    return () => {
+      if (processRef.current) {
+        processRef.current.kill();
+        processRef.current = null;
+      }
+      if (instanceRef.current) {
+        instanceRef.current.teardown();
+        instanceRef.current = null;
+      }
+    };
+  }, []);
+
   const refreshProjectTree = useCallback(async () => {
     if (!instanceRef.current) return;
     const files = await readAllFiles(instanceRef.current);

--- a/src/styles.css
+++ b/src/styles.css
@@ -191,13 +191,116 @@ button {
   font-size: 0.85rem;
   background: #f1f5f9;
   padding: 0.75rem;
-  border-radius: 8px;
-  max-height: 160px;
+  border-radius: 12px;
+  max-height: 180px;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.action-log h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
 }
 
 .action-log-entry {
-  margin-bottom: 0.5rem;
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.action-log-entry:last-child {
+  margin-bottom: 0;
+}
+
+.action-log.compact {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  max-height: none;
+  gap: 0;
+}
+
+.action-log.compact .action-log-entry {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0.35rem 0;
+}
+
+.action-log.compact .action-log-entry + .action-log-entry {
+  border-top: 1px solid #e2e8f0;
+}
+
+.action-log-empty {
+  color: #64748b;
+  font-style: italic;
+}
+
+.action-log-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.action-target {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.8rem;
+  color: #0f172a;
+}
+
+.action-meta {
+  color: #475569;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.status-badge.status-success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-badge.status-error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.status-badge.status-pending {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.action-output {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.75rem;
+  max-height: 140px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+.side-action-log {
+  margin-left: 1rem;
+  flex: 0 0 280px;
 }
 
 .badge {


### PR DESCRIPTION
## Summary
- add a reusable ActionLog component that surfaces status, cwd, and command output details
- refactor the chat panel to consume the shared log component and refresh the sidebar layout
- update WebContainer cleanup to kill running processes and teardown the instance when unmounting
- refresh action log styling for compact inline renders and sidebar presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4f0e9eca4832f885d58192becc114