### PR TITLE
Adopt AI Elements UI primitives for chat workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ npm run preview
 - Enhance the editor by swapping the textarea for Monaco or CodeMirror.
 - Stream AI responses token-by-token by switching to `streamObject` in the API.
 
+## AI Elements quick start (optional)
+
+If you are building a separate Next.js front end that consumes the Tribe API, you can scaffold chat interfaces with the AI Elements component library. The essentials:
+
+- **Prerequisites** – Node.js 18+, a Next.js project with the [AI SDK](https://ai-sdk.dev), `shadcn/ui` initialized, and Tailwind CSS in CSS variables mode.
+- **Install everything** – `npx ai-elements@latest`
+- **Install specific pieces** – `npx ai-elements@latest add <component>` (e.g. `message`, `conversation`, `code-block`).
+- **Alternative via shadcn** – `npx shadcn@latest add https://registry.ai-sdk.dev/registry.json`
+
+After installation you can render chat UIs using the exported primitives such as `Conversation`, `Message`, and `Response` alongside `useChat` from `@ai-sdk/react`.
+
 ## Troubleshooting
 
 | Issue | Resolution |

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,5 +1,15 @@
-import { FormEvent, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { ChatMessage, ActionResult } from '../lib/types';
+import {
+  Conversation,
+  ConversationContent,
+  Message,
+  MessageContent,
+  Response,
+  PromptForm,
+  PromptInput,
+  CodeBlock,
+} from './ai-elements';
 
 interface ChatPanelProps {
   messages: ChatMessage[];
@@ -8,67 +18,120 @@ interface ChatPanelProps {
   actionLog: ActionResult[];
 }
 
+function truncateContent(content: string, limit = 800) {
+  if (content.length <= limit) {
+    return content;
+  }
+  return `${content.slice(0, limit)}\n… (truncated)`;
+}
+
+function ActionDetails({ action }: { action: ActionResult }) {
+  const status = action.status ?? 'pending';
+  const isCommand = action.type === 'runCommand';
+  const descriptor = isCommand ? action.command : action.path;
+
+  return (
+    <div className="message-action-card">
+      <div className="message-action-header">
+        <span className="badge">{action.type}</span>
+        <span className={`action-status action-status-${status}`}>{status}</span>
+      </div>
+      <code className="message-action-target">{descriptor}</code>
+      {action.message ? <p className="message-action-message">{action.message}</p> : null}
+      {isCommand ? (
+        action.output ? (
+          <CodeBlock language="bash" label="Command output">
+            {action.output}
+          </CodeBlock>
+        ) : null
+      ) : action.type === 'createOrUpdateFile' ? (
+        <CodeBlock language="plaintext" label="Updated contents">
+          {truncateContent(action.content)}
+        </CodeBlock>
+      ) : null}
+    </div>
+  );
+}
+
 export function ChatPanel({ messages, onSend, isProcessing, actionLog }: ChatPanelProps) {
   const [draft, setDraft] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!draft.trim()) {
+  const handleSubmit = useCallback(async () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setSubmitError('Enter a prompt to continue.');
       return;
     }
-    const message = draft.trim();
+    setSubmitError(null);
     setDraft('');
-    await onSend(message);
-  };
+    try {
+      await onSend(trimmed);
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Failed to send prompt.');
+      setDraft(trimmed);
+    }
+  }, [draft, onSend]);
 
   return (
     <div className="panel chat-panel">
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-        <h3>Chatbot</h3>
-        <div className="chat-messages">
-          {messages.map((message) => (
-            <div key={message.id} className="chat-message">
-              <div className="role">{message.role === 'assistant' ? 'Assistant' : 'You'}</div>
-              <div>{message.content}</div>
-              {message.actions && message.actions.length > 0 ? (
-                <div className="action-log">
-                  {message.actions.map((action, index) => (
-                    <div key={`${action.type}-${index}`} className="action-log-entry">
-                      <span className="badge">{action.type}</span>
-                      <div>{'path' in action ? action.path : action.command}</div>
-                      {action.status ? <div>Status: {action.status}</div> : null}
-                      {action.message ? <div>{action.message}</div> : null}
+      <Conversation>
+        <ConversationContent>
+          {messages.length === 0 ? (
+            <div className="chat-placeholder">Ask the assistant to scaffold a project or run a command.</div>
+          ) : (
+            messages.map((message) => (
+              <Message key={message.id} from={message.role === 'assistant' ? 'assistant' : 'user'}>
+                <MessageContent>
+                  <Response>{message.content}</Response>
+                  {message.error ? <div className="message-error">{message.error}</div> : null}
+                  {message.actions && message.actions.length > 0 ? (
+                    <div className="message-actions">
+                      {message.actions.map((action, index) => (
+                        <ActionDetails key={`${action.type}-${index}`} action={action} />
+                      ))}
                     </div>
-                  ))}
-                </div>
-              ) : null}
-              {message.error ? <div className="action-log-entry">Error: {message.error}</div> : null}
-            </div>
-          ))}
-        </div>
-        <form className="chat-input" onSubmit={handleSubmit}>
-          <textarea
+                  ) : null}
+                </MessageContent>
+              </Message>
+            ))
+          )}
+        </ConversationContent>
+        <PromptForm onSubmit={handleSubmit} isPending={isProcessing}>
+          <PromptInput
             value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            placeholder="Ask for scaffolding, dependencies, debugging help, or command execution"
+            onChange={(value) => {
+              setDraft(value);
+              if (submitError) {
+                setSubmitError(null);
+              }
+            }}
+            placeholder="Describe what you want to build, request file updates, or run commands"
+            disabled={isProcessing}
           />
-          <button type="submit" disabled={isProcessing}>
-            {isProcessing ? 'Processing…' : 'Send'}
-          </button>
-        </form>
-      </div>
-      <div className="action-log" style={{ marginLeft: '1rem', flex: '0 0 280px' }}>
+          {submitError ? <p className="prompt-error" role="alert">{submitError}</p> : null}
+        </PromptForm>
+      </Conversation>
+      <aside className="chat-action-log" aria-live="polite">
         <h4>Latest actions</h4>
-        {actionLog.length === 0 && <div>No actions executed yet.</div>}
-        {actionLog.map((action, index) => (
-          <div key={`${action.type}-${index}`} className="action-log-entry">
-            <strong>{action.type}</strong>
-            <div>{'path' in action ? action.path : action.command}</div>
-            {action.status ? <div>Status: {action.status}</div> : null}
-            {action.message ? <div>{action.message}</div> : null}
-          </div>
-        ))}
-      </div>
+        {actionLog.length === 0 ? <p>No actions executed yet.</p> : null}
+        <div className="chat-action-log-entries">
+          {actionLog.map((action, index) => {
+            const status = action.status ?? 'pending';
+            const descriptor = action.type === 'runCommand' ? action.command : action.path;
+            return (
+              <div key={`${action.type}-${index}`} className="action-log-entry">
+                <div className="action-log-header">
+                  <span className="badge">{action.type}</span>
+                  <span className={`action-status action-status-${status}`}>{status}</span>
+                </div>
+                <div className="action-log-body">{descriptor}</div>
+                {action.message ? <div className="action-log-message">{action.message}</div> : null}
+              </div>
+            );
+          })}
+        </div>
+      </aside>
     </div>
   );
 }

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -1,3 +1,5 @@
+import { Terminal } from './ai-elements';
+
 interface TerminalPanelProps {
   output: string;
 }
@@ -6,7 +8,7 @@ export function TerminalPanel({ output }: TerminalPanelProps) {
   return (
     <div className="panel">
       <h3>Terminal</h3>
-      <div className="terminal-output">{output || 'Terminal output will appear here.'}</div>
+      <Terminal output={output} />
     </div>
   );
 }

--- a/src/components/ai-elements/CodeBlock.tsx
+++ b/src/components/ai-elements/CodeBlock.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+interface CodeBlockProps {
+  language?: string;
+  children: ReactNode;
+  label?: string;
+}
+
+export function CodeBlock({ language, children, label }: CodeBlockProps) {
+  return (
+    <div className="code-block" role="group" aria-label={label ?? language ?? 'Code block'}>
+      {label ? <div className="code-block-label">{label}</div> : null}
+      <pre>
+        <code data-language={language}>{children}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/components/ai-elements/Conversation.tsx
+++ b/src/components/ai-elements/Conversation.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface ConversationProps {
+  children: ReactNode;
+}
+
+export function Conversation({ children }: ConversationProps) {
+  return <section className="conversation">{children}</section>;
+}
+
+interface ConversationContentProps {
+  children: ReactNode;
+}
+
+export function ConversationContent({ children }: ConversationContentProps) {
+  return <div className="conversation-content">{children}</div>;
+}

--- a/src/components/ai-elements/Message.tsx
+++ b/src/components/ai-elements/Message.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+interface MessageProps {
+  from: 'user' | 'assistant';
+  children: ReactNode;
+  status?: 'pending' | 'complete' | 'error';
+}
+
+export function Message({ from, children, status }: MessageProps) {
+  const classes = ['message'];
+  if (from === 'user') classes.push('message-user');
+  if (from === 'assistant') classes.push('message-assistant');
+  if (status === 'pending') classes.push('message-pending');
+  if (status === 'error') classes.push('message-error');
+
+  return (
+    <article className={classes.join(' ')} aria-live={from === 'assistant' ? 'polite' : undefined}>
+      <header className="message-header">
+        <span className="message-author">{from === 'assistant' ? 'Assistant' : 'You'}</span>
+        {status ? <span className={`message-status message-status-${status}`}>{status}</span> : null}
+      </header>
+      {children}
+    </article>
+  );
+}
+
+interface MessageContentProps {
+  children: ReactNode;
+}
+
+export function MessageContent({ children }: MessageContentProps) {
+  return <div className="message-content">{children}</div>;
+}

--- a/src/components/ai-elements/PromptForm.tsx
+++ b/src/components/ai-elements/PromptForm.tsx
@@ -1,0 +1,25 @@
+import type { FormEvent, ReactNode } from 'react';
+
+interface PromptFormProps {
+  children: ReactNode;
+  onSubmit: () => void | Promise<void>;
+  isPending?: boolean;
+}
+
+export function PromptForm({ children, onSubmit, isPending }: PromptFormProps) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void onSubmit();
+  };
+
+  return (
+    <form className="prompt-form" onSubmit={handleSubmit} aria-busy={isPending}>
+      <div className="prompt-form-body">{children}</div>
+      <div className="prompt-form-actions">
+        <button type="submit" disabled={isPending}>
+          {isPending ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/ai-elements/PromptInput.tsx
+++ b/src/components/ai-elements/PromptInput.tsx
@@ -1,0 +1,26 @@
+import type { ChangeEvent } from 'react';
+
+interface PromptInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function PromptInput({ value, onChange, placeholder, disabled }: PromptInputProps) {
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <textarea
+      className="prompt-input"
+      value={value}
+      onChange={handleChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      rows={4}
+      spellCheck={false}
+    />
+  );
+}

--- a/src/components/ai-elements/Response.tsx
+++ b/src/components/ai-elements/Response.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+interface ResponseProps {
+  children: ReactNode;
+}
+
+export function Response({ children }: ResponseProps) {
+  return <div className="response">{children}</div>;
+}

--- a/src/components/ai-elements/Terminal.tsx
+++ b/src/components/ai-elements/Terminal.tsx
@@ -1,0 +1,12 @@
+interface TerminalProps {
+  output: string;
+  emptyPlaceholder?: string;
+}
+
+export function Terminal({ output, emptyPlaceholder = 'Terminal output will appear here.' }: TerminalProps) {
+  return (
+    <div className="terminal" role="log" aria-live="polite">
+      <pre>{output ? output : emptyPlaceholder}</pre>
+    </div>
+  );
+}

--- a/src/components/ai-elements/index.ts
+++ b/src/components/ai-elements/index.ts
@@ -1,0 +1,7 @@
+export { Conversation, ConversationContent } from './Conversation';
+export { Message, MessageContent } from './Message';
+export { Response } from './Response';
+export { PromptForm } from './PromptForm';
+export { PromptInput } from './PromptInput';
+export { CodeBlock } from './CodeBlock';
+export { Terminal } from './Terminal';

--- a/src/styles.css
+++ b/src/styles.css
@@ -85,45 +85,316 @@ button {
 .chat-panel {
   grid-column: 1 / span 2;
   display: flex;
+  gap: 1rem;
 }
 
-.chat-messages {
+.conversation {
   flex: 1;
-  overflow-y: auto;
-  padding-right: 0.5rem;
-}
-
-.chat-message {
-  margin-bottom: 1rem;
-}
-
-.chat-message .role {
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-.chat-input {
   display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+  flex-direction: column;
 }
 
-.chat-input textarea {
+.conversation-content {
   flex: 1;
-  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-right: 1rem;
+  overflow-y: auto;
+}
+
+.chat-placeholder {
+  color: #475569;
+  font-size: 0.95rem;
+  padding: 1.5rem;
+  background: #f8fafc;
+  border: 1px dashed #cbd5f5;
+  border-radius: 12px;
+  text-align: center;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.04);
+}
+
+.message-user {
+  background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+  align-self: flex-end;
+}
+
+.message-assistant {
+  background: #fff;
+}
+
+.message-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.message-author {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.message-status {
+  font-size: 0.75rem;
+  text-transform: capitalize;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.message-status-error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.message-status-complete {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.message-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.response {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.95rem;
+}
+
+.message-error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.message-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message-action-card {
+  background: #f1f5f9;
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid #e2e8f0;
+}
+
+.message-action-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.message-action-target {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.85rem;
+  background: #e2e8f0;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  align-self: flex-start;
+}
+
+.message-action-message {
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.prompt-form {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: #f8fafc;
+  border: 1px solid #cbd5f5;
+  border-radius: 16px;
+  padding: 0.75rem;
+}
+
+.prompt-input {
+  flex: 1;
+  min-height: 96px;
   padding: 0.75rem;
   border-radius: 12px;
   border: 1px solid #cbd5f5;
   resize: vertical;
+  font-size: 0.95rem;
+  background: #fff;
 }
 
-.chat-input button {
-  padding: 0.75rem 1.25rem;
+.prompt-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.prompt-form-actions button {
+  padding: 0.65rem 1.5rem;
   border-radius: 12px;
   border: none;
   background: #2563eb;
   color: #fff;
   font-weight: 600;
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
+}
+
+.prompt-form[aria-busy='true'] button {
+  opacity: 0.65;
+}
+
+.prompt-error {
+  color: #b91c1c;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.chat-action-log {
+  flex: 0 0 280px;
+  background: #f8fafc;
+  border-radius: 14px;
+  border: 1px solid #e2e8f0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-action-log h4 {
+  margin: 0;
+}
+
+.chat-action-log-entries {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.action-log-entry {
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.75rem;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.action-log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.action-log-body {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  word-break: break-word;
+}
+
+.action-log-message {
+  color: #475569;
+}
+
+.action-status {
+  font-size: 0.75rem;
+  text-transform: capitalize;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.action-status-success {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.action-status-error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.code-block {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 10px;
+  overflow: hidden;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.code-block-label {
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.code-block pre {
+  margin: 0;
+  padding: 0.75rem;
+  overflow-x: auto;
+}
+
+.terminal {
+  flex: 1;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+.terminal pre {
+  margin: 0;
+}
+
+.preview-frame {
+  flex: 1;
+  border: none;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.status-bar {
+  font-size: 0.85rem;
+  color: #475569;
+  margin-bottom: 0.75rem;
 }
 
 .file-tree {
@@ -162,55 +433,6 @@ button {
   background-color: #f8fafc;
 }
 
-.terminal-output {
-  flex: 1;
-  background: #0f172a;
-  color: #e2e8f0;
-  border-radius: 12px;
-  padding: 1rem;
-  font-family: 'Fira Code', 'Courier New', monospace;
-  overflow-y: auto;
-  white-space: pre-wrap;
-}
-
-.preview-frame {
-  flex: 1;
-  border: none;
-  border-radius: 12px;
-  background: #f8fafc;
-}
-
-.status-bar {
-  font-size: 0.85rem;
-  color: #475569;
-  margin-bottom: 0.75rem;
-}
-
-.action-log {
-  margin-top: 1rem;
-  font-size: 0.85rem;
-  background: #f1f5f9;
-  padding: 0.75rem;
-  border-radius: 8px;
-  max-height: 160px;
-  overflow-y: auto;
-}
-
-.action-log-entry {
-  margin-bottom: 0.5rem;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  background: #e0f2fe;
-  color: #0369a1;
-}
-
 .loader {
   width: 14px;
   height: 14px;
@@ -234,10 +456,14 @@ button {
 
   .main-content {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr 220px;
+    grid-template-rows: repeat(3, minmax(220px, 1fr));
   }
 
   .chat-panel {
-    grid-column: 1;
+    flex-direction: column;
+  }
+
+  .chat-action-log {
+    flex: unset;
   }
 }


### PR DESCRIPTION
## Summary
- add AI Elements-inspired Conversation, Message, PromptForm, CodeBlock, and Terminal primitives to support the chat workflow
- refactor the chat panel to render conversations, action details, and validation using the new components
- refresh shared styling and hook the terminal panel into the new Terminal component for a cohesive UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4f29c3f5c832fa8b7a4b5161a1f99