### PR TITLE
Add assistant message actions with like control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "ai": "^3.2.15",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "lucide-react": "^0.545.0",
         "morgan": "^1.10.0",
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
@@ -3047,6 +3048,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.545.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.545.0.tgz",
+      "integrity": "sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ai": "^3.2.15",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "lucide-react": "^0.545.0",
     "morgan": "^1.10.0",
     "path-browserify": "^1.0.1",
     "react": "^18.2.0",
@@ -36,8 +37,8 @@
     "@types/uuid": "^9.0.7",
     "@vitejs/plugin-react": "^4.2.1",
     "concurrently": "^8.2.0",
+    "tsx": "^4.7.1",
     "typescript": "^5.4.5",
-    "vite": "^5.1.6",
-    "tsx": "^4.7.1"
+    "vite": "^5.1.6"
   }
 }

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,6 @@
 import { FormEvent, useState } from 'react';
+import { ThumbsUpIcon } from 'lucide-react';
+import { Actions, Action } from '@/components/ai-elements/actions';
 import type { ChatMessage, ActionResult } from '../lib/types';
 import { ActionLog } from './ActionLog';
 
@@ -11,6 +13,19 @@ interface ChatPanelProps {
 
 export function ChatPanel({ messages, onSend, isProcessing, actionLog }: ChatPanelProps) {
   const [draft, setDraft] = useState('');
+  const [likedMessages, setLikedMessages] = useState<Set<string>>(() => new Set());
+
+  const handleToggleLike = (messageId: string) => {
+    setLikedMessages((prev) => {
+      const next = new Set(prev);
+      if (next.has(messageId)) {
+        next.delete(messageId);
+      } else {
+        next.add(messageId);
+      }
+      return next;
+    });
+  };
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -27,14 +42,30 @@ export function ChatPanel({ messages, onSend, isProcessing, actionLog }: ChatPan
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <h3>Chatbot</h3>
         <div className="chat-messages">
-          {messages.map((message) => (
-            <div key={message.id} className="chat-message">
-              <div className="role">{message.role === 'assistant' ? 'Assistant' : 'You'}</div>
-              <div>{message.content}</div>
-              {message.actions ? <ActionLog actions={message.actions} compact /> : null}
-              {message.error ? <div className="action-log-entry">Error: {message.error}</div> : null}
-            </div>
-          ))}
+          {messages.map((message) => {
+            const isAssistant = message.role === 'assistant';
+            const isLiked = likedMessages.has(message.id);
+
+            return (
+              <div key={message.id} className="chat-message">
+                <div className="role">{isAssistant ? 'Assistant' : 'You'}</div>
+                <div>{message.content}</div>
+                {message.actions ? <ActionLog actions={message.actions} compact /> : null}
+                {message.error ? <div className="action-log-entry">Error: {message.error}</div> : null}
+                {isAssistant ? (
+                  <Actions className="message-actions">
+                    <Action
+                      label={isLiked ? 'Remove like' : 'Like'}
+                      aria-pressed={isLiked}
+                      onClick={() => handleToggleLike(message.id)}
+                    >
+                      <ThumbsUpIcon aria-hidden="true" className="size-4" />
+                    </Action>
+                  </Actions>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
         <form className="chat-input" onSubmit={handleSubmit}>
           <textarea

--- a/src/components/ai-elements/actions.tsx
+++ b/src/components/ai-elements/actions.tsx
@@ -1,0 +1,40 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export interface ActionsProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function Actions({ className, children, ...props }: ActionsProps) {
+  return (
+    <div
+      role="group"
+      aria-label={props['aria-label'] ?? 'Message actions'}
+      className={cn('actions-root', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface ActionProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export function Action({ label, className, children, type = 'button', ...props }: ActionProps) {
+  return (
+    <button
+      type={type}
+      className={cn('action-button', className)}
+      aria-label={props['aria-label'] ?? label}
+      {...props}
+    >
+      {children}
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -251,6 +251,62 @@ button {
   gap: 0.5rem;
 }
 
+.message-actions {
+  margin-top: 0.5rem;
+}
+
+.actions-root {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 1px solid #cbd5f5;
+  background: #fff;
+  color: #0f172a;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.action-button:hover {
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.action-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.action-button[aria-pressed='true'] {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.size-4 {
+  width: 1rem;
+  height: 1rem;
+}
+
 .action-target {
   font-family: 'Fira Code', 'Courier New', monospace;
   font-size: 0.8rem;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "allowJs": false,
     "jsx": "react-jsx",
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
   plugins: [react()],
@@ -17,6 +18,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
       path: 'path-browserify',
     },
   },


### PR DESCRIPTION
## Summary
- add reusable Actions and Action components for chat message controls
- enhance the chat panel with a like toggle on assistant messages using lucide-react icons
- configure project aliases and styles to support the new action components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4f77d2624832fb599a3de59025906