### PR TITLE
Add Groq provider support and Star of David branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An AI-powered developer companion that combines the [Tribe WebContainer Runtime]
 
 - **WebContainer orchestration** – Boot, manage, and teardown a WebContainer workspace directly from the chat UI.
 - **AI-guided workflows** – Uses Gemini 2.5 Flash via the `ai-sdk-provider-gemini-cli` provider and structured outputs to generate actionable instructions.
+- **Groq + Gemini model flexibility** – Switch between Gemini and Groq large language models by configuring environment variables.
 - **File system management** – Create, edit, and delete files/folders using natural language commands or the built-in editor.
 - **Command execution** – Run arbitrary shell commands (`npm install`, `npm run dev`, etc.) with realtime terminal output.
 - **Live preview** – Automatically capture dev-server previews and stream them inside the app.
@@ -44,9 +45,18 @@ npm install
 
 Create a `.env` file at the project root and supply your preferred authentication method:
 
+- **Groq (new!)**
+
+  ```bash
+  AI_PROVIDER=groq
+  GROQ_API_KEY=your_groq_api_key
+  GROQ_MODEL=deepseek-r1-distill-llama-70b # optional – defaults to this value
+  ```
+
 - **API key (recommended)**
 
   ```bash
+  AI_PROVIDER=gemini
   GEMINI_API_KEY=your_api_key_here
   GEMINI_AUTH_TYPE=api-key
   ```
@@ -58,6 +68,49 @@ Create a `.env` file at the project root and supply your preferred authenticatio
   ```
 
 If you are migrating from earlier versions you can continue to use `GOOGLE_GENERATIVE_AI_API_KEY`; it is treated as a fallback for `GEMINI_API_KEY`.
+
+### Groq quickstart
+
+Groq support enables high-speed inference and large-context chat models. Once the environment variables are configured, the existing `/api/chat` endpoint will automatically route requests through Groq.
+
+#### Node streaming example
+
+```ts
+import { groq } from '@ai-sdk/groq';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: groq('deepseek-r1-distill-llama-70b'),
+  prompt: 'Invent a new holiday and describe its traditions.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+#### cURL example
+
+```bash
+curl "https://api.groq.com/openai/v1/chat/completions" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GROQ_API_KEY" \
+  -d '{
+         "messages": [
+           {
+             "role": "user",
+             "content": "Why is fast inference so important for AI applications?"
+           }
+         ],
+         "model": "qwen-qwq-32b",
+         "temperature": 0.6,
+         "max_completion_tokens": 32768,
+         "top_p": 0.95,
+         "stream": true,
+         "stop": null
+       }'
+```
 
 ### 3. Start the development servers
 
@@ -90,6 +143,42 @@ npm run preview
 2. **Structured AI output** – The API uses `generateObject` with a strict Zod schema so Gemini replies with executable actions (`createOrUpdateFile`, `deletePath`, `runCommand`).
 3. **Action execution** – The frontend streams these actions to the WebContainer runtime, updating the filesystem, running commands, and refreshing the workspace automatically.
 4. **Observability** – Each action’s status is surfaced in the chat transcript and the action log; terminal output and server previews are captured in dedicated panels.
+
+### Resumable streams (experimental)
+
+The `useChat` hook from `@ai-sdk/react` exposes an `experimental_resume` helper that can pick up an in-flight stream after a refresh or network disconnect. To enable it:
+
+1. Install the [`resumable-stream`](https://www.npmjs.com/package/resumable-stream) package and provision a Redis instance. Set `REDIS_URL` (or `KV_URL`) so the API can persist stream state.
+2. Create a table to associate chat IDs with stream IDs.
+3. Call `experimental_resume` once when your chat component mounts:
+
+   ```tsx
+   'use client';
+
+   import { useChat } from '@ai-sdk/react';
+   import { useEffect } from 'react';
+
+   export function Chat({ id }: { id: string }) {
+     const { experimental_resume } = useChat({ id });
+
+     useEffect(() => {
+       experimental_resume();
+     }, [experimental_resume]);
+
+     return <div>{/* chat UI */}</div>;
+   }
+   ```
+
+`experimental_resume` issues a `GET` request to your chat endpoint (e.g., `/api/chat?chatId=<id>`). If a stream is active it resumes token delivery; otherwise the call completes without error.
+
+### Prompt design with XML
+
+Using XML tags in system prompts clarifies structure for complex instructions:
+
+- **Structure and organization** – Tags such as `<context>`, `<instructions>`, and `<output>` provide explicit boundaries for each section.
+- **Clarity and readability** – Descriptive tags reduce ambiguity for both humans and the model.
+- **Consistency** – Reusable tag schemas keep prompts uniform across projects.
+- **Improved instruction following** – The explicit hierarchy helps models execute multi-step tasks and respect output formats.
 
 ## Safety considerations
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tribe AI Chatbot</title>
+    <link rel="icon" type="image/svg+xml" href="/star-of-david.svg" />
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tribe-ai-chatbot",
       "version": "1.0.0",
       "dependencies": {
+        "@ai-sdk/groq": "^2.0.22",
         "@types/node": "^20.11.30",
         "@webcontainer/api": "^1.1.9",
         "ai": "^3.2.15",
@@ -34,6 +35,39 @@
         "tsx": "^4.7.1",
         "typescript": "^5.4.5",
         "vite": "^5.1.6"
+      }
+    },
+    "node_modules/@ai-sdk/groq": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-2.0.22.tgz",
+      "integrity": "sha512-/AswqcXnMuZnpLzRxddB/WBEi0hM6IpqafrGGQE/jGQPIuIKPb8HyNatX67vJgHcD2s12YIKuFccaBPDYlUIVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/groq/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.10.tgz",
+      "integrity": "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "npm run build && concurrently \"node dist/server/index.js\" \"vite preview --host\""
   },
   "dependencies": {
+    "@ai-sdk/groq": "^2.0.22",
     "@types/node": "^20.11.30",
     "@webcontainer/api": "^1.1.9",
     "ai": "^3.2.15",

--- a/public/star-of-david.svg
+++ b/public/star-of-david.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Star of David Icon</title>
+  <defs>
+    <linearGradient id="starGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <path d="M32 4L55 44H9L32 4Z" fill="url(#starGradient)" />
+  <path d="M32 60L9 20H55L32 60Z" fill="url(#starGradient)" />
+</svg>

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,34 +4,55 @@ import morgan from 'morgan';
 import { generateObject } from 'ai';
 import type { LanguageModel } from 'ai';
 import { createGeminiProvider } from 'ai-sdk-provider-gemini-cli';
+import { createGroq } from '@ai-sdk/groq';
 import { z } from 'zod';
 import { assistantResponseSchema, chatRequestSchema, ChatRequest } from './types';
 
 const PORT = Number(process.env.PORT ?? 8787);
 
 type GeminiAuthType = 'oauth-personal' | 'api-key' | 'gemini-api-key';
+type ProviderName = 'gemini' | 'groq';
+
+const providerName = (process.env.AI_PROVIDER ?? 'gemini') as ProviderName;
 
 const geminiAuthTypeEnv = process.env.GEMINI_AUTH_TYPE as GeminiAuthType | undefined;
 const geminiApiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 const geminiAuthType: GeminiAuthType = geminiAuthTypeEnv ?? (geminiApiKey ? 'api-key' : 'oauth-personal');
+const missingGeminiApiKey = geminiAuthType !== 'oauth-personal' && !geminiApiKey;
 
-const missingApiKey = geminiAuthType !== 'oauth-personal' && !geminiApiKey;
+const groqApiKey = process.env.GROQ_API_KEY;
+const groqModelName = process.env.GROQ_MODEL ?? 'deepseek-r1-distill-llama-70b';
 
-if (missingApiKey) {
-  console.warn(
-    'Missing GEMINI_API_KEY environment variable. Configure GEMINI_API_KEY or switch GEMINI_AUTH_TYPE to "oauth-personal" to enable AI features.'
-  );
+let modelFactory: (() => LanguageModel) | null = null;
+
+if (providerName === 'groq') {
+  if (!groqApiKey) {
+    console.warn('Missing GROQ_API_KEY environment variable. Configure GROQ_API_KEY to enable Groq responses.');
+  } else {
+    const groqProvider = createGroq({ apiKey: groqApiKey });
+    modelFactory = () => groqProvider(groqModelName) as unknown as LanguageModel;
+  }
+} else {
+  if (missingGeminiApiKey) {
+    console.warn(
+      'Missing GEMINI_API_KEY environment variable. Configure GEMINI_API_KEY or switch GEMINI_AUTH_TYPE to "oauth-personal" to enable AI features.'
+    );
+  }
+
+  const gemini = !missingGeminiApiKey
+    ? createGeminiProvider(
+        geminiAuthType === 'oauth-personal'
+          ? { authType: 'oauth-personal' }
+          : { authType: geminiAuthType, apiKey: geminiApiKey as string }
+      )
+    : null;
+
+  const geminiModelName = process.env.GEMINI_MODEL ?? 'gemini-2.5-flash';
+
+  if (gemini) {
+    modelFactory = () => gemini(geminiModelName) as unknown as LanguageModel;
+  }
 }
-
-const gemini = !missingApiKey
-  ? createGeminiProvider(
-      geminiAuthType === 'oauth-personal'
-        ? { authType: 'oauth-personal' }
-        : { authType: geminiAuthType, apiKey: geminiApiKey as string }
-    )
-  : null;
-
-const modelName = process.env.GEMINI_MODEL ?? 'gemini-2.5-flash';
 
 const app = express();
 app.use(cors());
@@ -61,8 +82,8 @@ app.get('/health', (_req, res) => {
 });
 
 app.post('/api/chat', async (req, res) => {
-  if (!gemini) {
-    return res.status(503).json({ error: 'Gemini provider not configured.' });
+  if (!modelFactory) {
+    return res.status(503).json({ error: 'AI provider not configured.' });
   }
 
   const parseResult = chatRequestSchema.safeParse(req.body);
@@ -71,7 +92,7 @@ app.post('/api/chat', async (req, res) => {
   }
 
   const requestPayload = parseResult.data;
-  const model = gemini(modelName);
+  const model = modelFactory();
 
   try {
     const { object } = await generateObject({
@@ -102,5 +123,6 @@ app.post('/api/chat', async (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`API server listening on http://localhost:${PORT}`);
+  const statusLabel = modelFactory ? providerName : 'unconfigured';
+  console.log(`API server listening on http://localhost:${PORT} (provider: ${statusLabel})`);
 });

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/src/assets/star-of-david.svg
+++ b/src/assets/star-of-david.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Star of David Icon</title>
+  <defs>
+    <linearGradient id="starGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <path d="M32 4L55 44H9L32 4Z" fill="url(#starGradient)" />
+  <path d="M32 60L9 20H55L32 60Z" fill="url(#starGradient)" />
+</svg>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightIcon, Code2Icon, MessageCircleIcon, MonitorSmartphoneIcon, SparklesIcon } from 'lucide-react';
+import logoUrl from '../assets/star-of-david.svg';
 
 interface LandingPageProps {
   onLaunch: () => void;
@@ -29,7 +30,10 @@ export function LandingPage({ onLaunch }: LandingPageProps) {
   return (
     <div className="landing-page">
       <header className="landing-nav">
-        <div className="landing-logo">Tribe</div>
+        <div className="landing-logo" aria-label="Tribe">
+          <img src={logoUrl} alt="Tribe logo" />
+          <span>Tribe</span>
+        </div>
         <div className="landing-nav-actions">
           <button type="button" className="secondary-button">
             View docs

--- a/src/styles.css
+++ b/src/styles.css
@@ -97,9 +97,17 @@ button {
 }
 
 .landing-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
   font-weight: 700;
   font-size: 1.25rem;
   letter-spacing: -0.02em;
+}
+
+.landing-logo img {
+  width: 32px;
+  height: 32px;
 }
 
 .landing-nav-actions {


### PR DESCRIPTION
## Summary
- add optional Groq model provider alongside the existing Gemini integration
- document Groq setup, resumable streaming, and prompt authoring guidance in the README
- refresh the landing page branding with a Star of David logo and favicon assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4fe652504832f8e43a20b9f7804ab