### PR TITLE
Refactor WebContainer boot helpers and extract AI prompt

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { createGeminiProvider } from 'ai-sdk-provider-gemini-cli';
 import { createGroq } from '@ai-sdk/groq';
 import { z } from 'zod';
 import { assistantResponseSchema, chatRequestSchema, ChatRequest } from './types';
+import { baseSystemPrompt } from './lib/.server/llm/prompts';
 
 const PORT = Number(process.env.PORT ?? 8787);
 
@@ -70,8 +71,6 @@ const app = express();
 app.use(cors());
 app.use(express.json({ limit: '2mb' }));
 app.use(morgan('dev'));
-
-const baseSystemPrompt = `You are Tribe, an AI agent that orchestrates a WebContainer workspace.\n\nYou can respond with a structured JSON payload describing actions to perform: write files, delete paths, and run commands. The user has a full Node.js environment with npm available.\n\nGuidelines:\n- Prefer small, incremental changes.\n- Run \\"npm install\\" before using a dependency.\n- Use runCommand for commands (install, build, start).\n- Always provide a concise natural language explanation in \\"reply\\".\n- File paths are relative to the project root.\n- Never include secrets.\n- Validate inputs and keep code safe.`;
 
 function buildContextSummary(request: ChatRequest): string {
   const dependencyList = request.projectSummary.dependencies.length

--- a/server/lib/.server/llm/prompts.ts
+++ b/server/lib/.server/llm/prompts.ts
@@ -1,0 +1,5 @@
+/**
+ * Canonical system prompt used by the AI orchestration layer when generating
+ * actions for the WebContainer workspace.
+ */
+export const baseSystemPrompt = `You are Tribe, an AI agent that orchestrates a WebContainer workspace.\n\nYou can respond with a structured JSON payload describing actions to perform: write files, delete paths, and run commands. The user has a full Node.js environment with npm available.\n\nGuidelines:\n- Prefer small, incremental changes.\n- Run \"npm install\" before using a dependency.\n- Use runCommand for commands (install, build, start).\n- Always provide a concise natural language explanation in \"reply\".\n- File paths are relative to the project root.\n- Never include secrets.\n- Validate inputs and keep code safe.`;

--- a/src/lib/webcontainer.client.ts
+++ b/src/lib/webcontainer.client.ts
@@ -1,0 +1,88 @@
+import { WebContainer, auth, type AuthAPI } from '@webcontainer/api';
+import { WORK_DIR_NAME } from '@/utils/constants';
+import { cleanStackTrace } from '@/utils/stacktrace';
+
+interface WebContainerContext {
+  loaded: boolean;
+  error: string | null;
+}
+
+export const webcontainerContext: WebContainerContext = {
+  loaded: false,
+  error: null,
+};
+
+let bootPromise: Promise<WebContainer> | null = null;
+let instance: WebContainer | null = null;
+
+export let webcontainer: Promise<WebContainer> = new Promise(() => {
+  // noop for ssr environments
+});
+
+function ensureClientEnvironment() {
+  if (typeof window === 'undefined') {
+    throw new Error('WebContainer can only be booted in a browser environment.');
+  }
+}
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    const cleaned = cleanStackTrace(error);
+    error.message = cleaned;
+    return error;
+  }
+
+  return new Error(cleanStackTrace(error));
+}
+
+export async function bootWebcontainer(): Promise<WebContainer> {
+  ensureClientEnvironment();
+
+  if (instance) {
+    return instance;
+  }
+
+  if (!bootPromise) {
+    bootPromise = WebContainer.boot({ workdirName: WORK_DIR_NAME })
+      .then((webcontainerInstance) => {
+        instance = webcontainerInstance;
+        webcontainerContext.loaded = true;
+        webcontainerContext.error = null;
+        return webcontainerInstance;
+      })
+      .catch((error) => {
+        const normalized = normalizeError(error);
+        webcontainerContext.loaded = false;
+        webcontainerContext.error = normalized.message;
+        bootPromise = null;
+        throw normalized;
+      });
+
+    webcontainer = bootPromise;
+  }
+
+  return bootPromise;
+}
+
+export function getCurrentWebcontainer(): WebContainer | null {
+  return instance;
+}
+
+export async function teardownWebcontainer(): Promise<void> {
+  if (instance) {
+    instance.teardown();
+    instance = null;
+  }
+  bootPromise = null;
+  webcontainerContext.loaded = false;
+  webcontainerContext.error = null;
+  webcontainer = new Promise(() => {
+    // noop for ssr environments
+  });
+}
+
+/**
+ * This client-only module exposes the WebContainer auth helpers to avoid
+ * bundling `@webcontainer/api` into server-side code.
+ */
+export { auth, type AuthAPI };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,6 @@
+export const WORK_DIR_NAME = 'tribe-workspace';
+
+export const DEFAULT_TERMINAL_DIMENSIONS = {
+  cols: 120,
+  rows: 40,
+} as const;

--- a/src/utils/stacktrace.ts
+++ b/src/utils/stacktrace.ts
@@ -1,0 +1,23 @@
+const INTERNAL_FRAME_PATTERNS = [/node_modules\//, /\(internal\//, /\bwebcontainer\b/i];
+
+function formatErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === 'string' ? error : JSON.stringify(error);
+}
+
+export function cleanStackTrace(error: unknown): string {
+  if (!(error instanceof Error) || !error.stack) {
+    return formatErrorMessage(error);
+  }
+
+  const [messageLine, ...stackLines] = error.stack.split('\n');
+  const filteredStack = stackLines.filter((line) => !INTERNAL_FRAME_PATTERNS.some((pattern) => pattern.test(line)));
+
+  if (!filteredStack.length) {
+    return messageLine ?? formatErrorMessage(error);
+  }
+
+  return [messageLine, ...filteredStack].join('\n');
+}


### PR DESCRIPTION
## Summary
- add a client-only WebContainer helper that centralizes boot/teardown logic, exposes auth helpers, and cleans stack traces
- update the WebContainer hook to consume the shared helper utilities and workspace constants
- extract the LLM system prompt into a dedicated server lib and add reusable constants/stacktrace utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e503f8cf28832fa19fc9234e54d1a0