### PR TITLE
Improve terminal auto-scroll heuristics

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -1,12 +1,59 @@
+import { useEffect, useRef } from 'react';
+
 interface TerminalPanelProps {
   output: string;
 }
 
 export function TerminalPanel({ output }: TerminalPanelProps) {
+  const outputRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScrollRef = useRef(true);
+
+  useEffect(() => {
+    const container = outputRef.current;
+    if (!container) {
+      return;
+    }
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const distanceFromBottom = scrollHeight - (scrollTop + clientHeight);
+
+      // Allow a small threshold so tiny scroll differences don't disable auto-scroll.
+      shouldAutoScrollRef.current = distanceFromBottom <= 16;
+    };
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    const container = outputRef.current;
+    if (!container || !shouldAutoScrollRef.current) {
+      return;
+    }
+
+    const animationFrame = requestAnimationFrame(() => {
+      container.scrollTop = container.scrollHeight;
+    });
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [output]);
+
   return (
     <div className="panel">
       <h3>Terminal</h3>
-      <div className="terminal-output">{output || 'Terminal output will appear here.'}</div>
+      <div
+        aria-live="polite"
+        role="log"
+        className="terminal-output"
+        ref={outputRef}
+      >
+        {output ? <pre>{output}</pre> : 'Terminal output will appear here.'}
+      </div>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -508,6 +508,13 @@ button {
   white-space: pre-wrap;
 }
 
+.terminal-output pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font: inherit;
+}
+
 .preview-frame {
   flex: 1;
   border: none;


### PR DESCRIPTION
## Summary
- track whether the terminal viewport is near the bottom before auto-scrolling
- only scroll after updates when the user has not manually scrolled away and use requestAnimationFrame for smoother behavior
- mark the terminal log region with an appropriate ARIA role to improve assistive technology support

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5070c534c832f820d85020feb39ae