### PR TITLE
feat: spotlight design mode on landing page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -126,6 +126,95 @@ export function LandingPage({ onLaunch }: LandingPageProps) {
             </article>
           ))}
         </section>
+
+        <section className="landing-design-mode">
+          <div className="landing-design-copy">
+            <span className="landing-eyebrow">Design mode</span>
+            <h2>Build visually, iterate instantly</h2>
+            <p>
+              Design mode provides an intuitive, visual way to build and refine your app&apos;s interface. Select any element in
+              the preview, inspect its properties, and make precise adjustments using natural language or the full design
+              control panel.
+            </p>
+
+            <div className="landing-design-grid">
+              <article>
+                <h3>Enable Design Mode</h3>
+                <ul>
+                  <li>
+                    <strong>Keyboard shortcut:</strong> Press <kbd>Option</kbd> + <kbd>D</kbd> to toggle Design Mode from
+                    anywhere.
+                  </li>
+                  <li>
+                    <strong>Using the UI:</strong> Open the <em>Design</em> tab at the top of the interface to switch from the
+                    chat view.
+                  </li>
+                </ul>
+              </article>
+
+              <article>
+                <h3>Select exactly what you need</h3>
+                <p>
+                  With Design Mode active, hovering over the preview highlights selectable regions so you can target the exact
+                  component you want to modify. Click any highlighted element to lock it into the design panel.
+                </p>
+              </article>
+
+              <article>
+                <h3>Modify elements your way</h3>
+                <ul>
+                  <li>
+                    <strong>Prompt for complex updates:</strong> Describe structural changes like &quot;add a button next to this
+                    text&quot; or &quot;make this a three-column grid&quot; for instant layout edits.
+                  </li>
+                  <li>
+                    <strong>Fine-tune in the panel:</strong> Adjust typography, colors, spacing, borders, radius, shadows, and
+                    more with Tailwind-native controls.
+                  </li>
+                </ul>
+              </article>
+
+              <article>
+                <h3>Stay on brand effortlessly</h3>
+                <p>
+                  The design panel reads directly from your <code>tailwind.config.js</code>, so every tweak uses your existing
+                  design tokens. Experiment freely—prompt-based updates use AI tokens, while panel adjustments are unlimited.
+                </p>
+              </article>
+
+              <article>
+                <h3>Save when it&apos;s perfect</h3>
+                <p>
+                  Once you&apos;re happy with the results, tap <strong>Save</strong> at the bottom of the preview to capture your
+                  edits and keep iterating with confidence.
+                </p>
+              </article>
+            </div>
+          </div>
+
+          <aside className="landing-design-aside" aria-hidden="true">
+            <div className="landing-design-card">
+              <span className="landing-eyebrow">Preview</span>
+              <h3>Design controls at a glance</h3>
+              <ul>
+                <li>Typography presets with weight, leading, and spacing adjustments.</li>
+                <li>Color, background, border, and shadow controls aligned with your tokens.</li>
+                <li>Layout tools for margin, padding, alignment, and responsive sizing.</li>
+                <li>Content editing to update copy inline while you design.</li>
+              </ul>
+            </div>
+          </aside>
+        </section>
+
+        <section className="landing-anyone">
+          <div className="landing-anyone-card">
+            <h2>Anyone, anywhere can build with Tribe</h2>
+            <p>
+              Turn your ideas into real web apps without writing code. Describe the experience you want, remix generated
+              layouts in Design Mode, and deploy with a single click—all from one collaborative canvas.
+            </p>
+          </div>
+        </section>
       </main>
     </div>
   );

--- a/src/components/ai-elements/artifact.tsx
+++ b/src/components/ai-elements/artifact.tsx
@@ -1,0 +1,85 @@
+import type { ComponentProps, HTMLAttributes } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export function Artifact({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('artifact', className)} {...props} />;
+}
+
+export function ArtifactHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('artifact-header', className)} {...props} />;
+}
+
+export function ArtifactTitle({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('artifact-title', className)} {...props} />;
+}
+
+export function ArtifactDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('artifact-description', className)} {...props} />;
+}
+
+export function ArtifactActions({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('artifact-actions', className)} {...props} />;
+}
+
+export interface ArtifactActionProps extends ComponentProps<typeof Button> {
+  tooltip?: string;
+  label?: string;
+  icon?: LucideIcon;
+}
+
+export function ArtifactAction({
+  tooltip,
+  label,
+  icon: Icon,
+  className,
+  children,
+  type = 'button',
+  ...props
+}: ArtifactActionProps) {
+  const ariaLabel = props['aria-label'] ?? label ?? tooltip;
+  const title = tooltip ?? label;
+
+  return (
+    <Button
+      type={type}
+      variant="ghost"
+      size="icon"
+      className={cn('artifact-action', className)}
+      title={title}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {Icon ? <Icon aria-hidden="true" className="size-4" /> : null}
+      {children}
+      {label && !children ? <span className="sr-only">{label}</span> : null}
+    </Button>
+  );
+}
+
+export type ArtifactCloseProps = ComponentProps<typeof Button>;
+
+export function ArtifactClose({ className, children, type = 'button', ...props }: ArtifactCloseProps) {
+  const ariaLabel = props['aria-label'] ?? 'Dismiss artifact';
+
+  return (
+    <Button
+      type={type}
+      variant="ghost"
+      size="icon"
+      className={cn('artifact-close', className)}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {children ?? <span aria-hidden="true">×</span>}
+    </Button>
+  );
+}
+
+export function ArtifactContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('artifact-content', className)} {...props} />;
+}

--- a/src/components/ai-elements/panel.tsx
+++ b/src/components/ai-elements/panel.tsx
@@ -1,0 +1,40 @@
+import type { ComponentProps } from 'react';
+import { Panel as ReactFlowPanel } from '@xyflow/react';
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export type PanelPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+const positionClassNames: Record<PanelPosition, string> = {
+  'top-left': 'ai-panel-top-left',
+  'top-center': 'ai-panel-top-center',
+  'top-right': 'ai-panel-top-right',
+  'bottom-left': 'ai-panel-bottom-left',
+  'bottom-center': 'ai-panel-bottom-center',
+  'bottom-right': 'ai-panel-bottom-right',
+};
+
+export interface PanelProps extends ComponentProps<typeof ReactFlowPanel> {
+  position?: PanelPosition;
+}
+
+export function Panel({ position = 'top-left', className, children, ...props }: PanelProps) {
+  return (
+    <ReactFlowPanel
+      position={position}
+      className={cn('ai-panel', positionClassNames[position], className)}
+      data-position={position}
+      {...props}
+    >
+      {children}
+    </ReactFlowPanel>
+  );
+}

--- a/src/components/ai-elements/toolbar.tsx
+++ b/src/components/ai-elements/toolbar.tsx
@@ -1,0 +1,12 @@
+import type { ComponentProps } from 'react';
+import { NodeToolbar } from '@xyflow/react';
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export interface ToolbarProps extends ComponentProps<typeof NodeToolbar> {}
+
+export function Toolbar({ className, position = 'bottom', ...props }: ToolbarProps) {
+  return <NodeToolbar position={position} className={cn('ai-toolbar', className)} {...props} />;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,38 @@
+import { forwardRef } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+const variantClassNames = {
+  default: 'ui-button-default',
+  ghost: 'ui-button-ghost',
+  outline: 'ui-button-outline',
+};
+
+const sizeClassNames = {
+  default: 'ui-button-size-default',
+  sm: 'ui-button-size-sm',
+  icon: 'ui-button-size-icon',
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof variantClassNames;
+  size?: keyof typeof sizeClassNames;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', type = 'button', ...props }, ref) => {
+    return (
+      <button
+        type={type}
+        className={cn('ui-button', variantClassNames[variant], sizeClassNames[size], className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/styles.css
+++ b/src/styles.css
@@ -338,6 +338,158 @@ button {
   line-height: 1.6;
 }
 
+.landing-design-mode {
+  margin-top: 4rem;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.landing-design-copy {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 28px;
+  padding: 2.5rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.landing-design-copy h2 {
+  font-size: 2rem;
+  margin: 0;
+  color: #0f172a;
+}
+
+.landing-design-copy > p {
+  margin: 0;
+  color: #334155;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.landing-design-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.landing-design-grid article {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.landing-design-grid h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.landing-design-grid p,
+.landing-design-grid li {
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.landing-design-grid ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.landing-design-grid kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.85rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.landing-design-grid code {
+  font-family: 'Source Code Pro', 'Fira Code', Menlo, monospace;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.15rem 0.35rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.landing-design-aside {
+  align-self: stretch;
+  display: flex;
+  align-items: stretch;
+}
+
+.landing-design-card {
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.18), rgba(29, 78, 216, 0.25)),
+    linear-gradient(145deg, #0f172a, #111c3a);
+  color: #f8fafc;
+  border-radius: 30px;
+  padding: 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.35);
+}
+
+.landing-design-card h3 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.landing-design-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.landing-design-card li::marker {
+  color: rgba(165, 180, 252, 0.9);
+}
+
+.landing-anyone {
+  margin-top: 4rem;
+}
+
+.landing-anyone-card {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.15), rgba(14, 165, 233, 0.12));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 32px;
+  padding: 3rem;
+  text-align: center;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.12);
+}
+
+.landing-anyone-card h2 {
+  margin: 0 0 1rem;
+  font-size: 2.1rem;
+  color: #0f172a;
+}
+
+.landing-anyone-card p {
+  margin: 0 auto;
+  max-width: 640px;
+  color: #334155;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
 .workspace-page {
   height: 100%;
   display: flex;
@@ -559,6 +711,22 @@ button {
     padding: 1.25rem;
   }
 
+  .landing-design-mode {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-design-aside {
+    order: -1;
+  }
+
+  .landing-design-copy {
+    padding: 2rem;
+  }
+
+  .landing-anyone-card {
+    padding: 2.25rem;
+  }
+
   .workspace-header {
     flex-direction: column;
     align-items: flex-start;
@@ -581,6 +749,14 @@ button {
 
   .landing-tip {
     font-size: 0.9rem;
+  }
+
+  .landing-design-copy h2 {
+    font-size: 1.6rem;
+  }
+
+  .landing-anyone-card h2 {
+    font-size: 1.8rem;
   }
 }
 
@@ -741,7 +917,251 @@ button {
 
 .side-action-log {
   margin-left: 1rem;
-  flex: 0 0 280px;
+  flex: 0 0 320px;
+  display: flex;
+  flex-direction: column;
+}
+
+.side-action-log-toggle {
+  margin-left: 1rem;
+  flex: 0 0 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ui-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  line-height: 1;
+  font-size: 0.95rem;
+}
+
+.ui-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.ui-button-size-default {
+  height: 2.5rem;
+  padding: 0 1rem;
+}
+
+.ui-button-size-sm {
+  height: 2.125rem;
+  padding: 0 0.75rem;
+  font-size: 0.85rem;
+}
+
+.ui-button-size-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+}
+
+.ui-button-default {
+  background-image: linear-gradient(135deg, #2563eb, #1d4ed8);
+  border-color: #1d4ed8;
+  color: #fff;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.28);
+}
+
+.ui-button-default:hover:not(:disabled) {
+  background-image: linear-gradient(135deg, #1d4ed8, #1e40af);
+  border-color: #1e40af;
+}
+
+.ui-button-ghost {
+  background: transparent;
+  color: #0f172a;
+}
+
+.ui-button-ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.ui-button-outline {
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(148, 163, 184, 0.6);
+  color: #1f2937;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+}
+
+.ui-button-outline:hover:not(:disabled) {
+  background: rgba(226, 232, 240, 0.95);
+  border-color: rgba(148, 163, 184, 0.8);
+}
+
+.ai-panel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 16px 42px rgba(15, 23, 42, 0.18);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.ai-toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(248, 250, 252, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(12px);
+}
+
+.ai-toolbar > * {
+  display: inline-flex;
+  align-items: center;
+}
+
+.artifact {
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-image: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.92));
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.16);
+  overflow: hidden;
+  min-width: 0;
+}
+
+.artifact-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.artifact-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.artifact-description {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.artifact-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.artifact-action,
+.artifact-close {
+  border-radius: 999px;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.artifact-content {
+  padding: 1rem 1.25rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.artifact-action-log {
+  margin: 0;
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  max-height: 300px;
+  box-shadow: none;
+}
+
+.artifact-action-log .action-log-entry {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.artifact-action-log .action-log-entry + .action-log-entry {
+  margin-top: 0.65rem;
+}
+
+.artifact-action-log .action-log-empty {
+  padding: 0.5rem 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ui-button-ghost {
+    color: #e2e8f0;
+  }
+
+  .ui-button-ghost:hover:not(:disabled) {
+    background: rgba(148, 163, 184, 0.18);
+  }
+
+  .ui-button-outline {
+    background: rgba(30, 41, 59, 0.7);
+    border-color: rgba(148, 163, 184, 0.55);
+    color: #e2e8f0;
+    box-shadow: 0 16px 32px rgba(2, 6, 23, 0.5);
+  }
+
+  .ui-button-outline:hover:not(:disabled) {
+    background: rgba(30, 41, 59, 0.85);
+    border-color: rgba(148, 163, 184, 0.75);
+  }
+
+  .ai-panel {
+    background: rgba(15, 23, 42, 0.78);
+    border-color: rgba(148, 163, 184, 0.45);
+    color: #e2e8f0;
+    box-shadow: 0 20px 48px rgba(2, 6, 23, 0.55);
+  }
+
+  .ai-toolbar {
+    background: rgba(15, 23, 42, 0.82);
+    border-color: rgba(148, 163, 184, 0.45);
+    box-shadow: 0 24px 54px rgba(2, 6, 23, 0.55);
+  }
+
+  .artifact {
+    background-image: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.88));
+    border-color: rgba(148, 163, 184, 0.45);
+    box-shadow: 0 32px 70px rgba(2, 6, 23, 0.6);
+  }
+
+  .artifact-title {
+    color: #e2e8f0;
+  }
+
+  .artifact-description {
+    color: #cbd5f5;
+  }
+
+  .artifact-action-log .action-log-entry {
+    background: rgba(15, 23, 42, 0.88);
+    border-color: rgba(148, 163, 184, 0.45);
+    color: #e2e8f0;
+    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.5);
+  }
 }
 
 .badge {


### PR DESCRIPTION
## Summary
- highlight design mode workflows, controls, and save flow directly on the landing page
- add inclusive "anyone can build" messaging with supporting copy
- extend landing page styles with new design-mode layout, cards, and responsive tweaks

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_b_68e50ddb56c0832f8eb6305f80a8a2c5