### PR TITLE
Improve FileExplorer keyboard accessibility

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -22,15 +22,17 @@ function renderTree(node: DirectoryNode, selectedPath: string | null, onSelect: 
             );
           }
           return (
-            <li
-              key={child.path}
-              className={selectedPath === child.path ? 'active' : ''}
-              onClick={() => onSelect(child)}
-            >
-              <span role="img" aria-label="file">
-                📄
-              </span>
-              {child.name}
+            <li key={child.path}>
+              <button
+                type="button"
+                className={selectedPath === child.path ? 'active' : ''}
+                onClick={() => onSelect(child)}
+              >
+                <span role="img" aria-label="file">
+                  📄
+                </span>
+                {child.name}
+              </button>
             </li>
           );
         })}

--- a/src/styles.css
+++ b/src/styles.css
@@ -624,17 +624,32 @@ button {
 .file-tree li {
   margin: 0;
   padding: 0.25rem 0;
+}
+
+.file-tree button {
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 0.5rem;
   border-radius: 8px;
-  padding-inline: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  text-align: left;
+  font: inherit;
 }
 
-.file-tree li:hover,
-.file-tree li.active {
+.file-tree button:hover,
+.file-tree button.active,
+.file-tree button:focus-visible {
   background: #eff6ff;
+}
+
+.file-tree button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .editor textarea {


### PR DESCRIPTION
## Summary
- wrap file explorer file entries in semantic buttons so they can be focused and activated with the keyboard
- update file tree styling to preserve layout, hover behavior, and add a clear focus indicator for keyboard users

## Testing
- `npm run build` *(fails: Cannot find module '@ai-sdk/cohere')*

------
https://chatgpt.com/codex/tasks/task_b_68e53c8da5c4832f956ad7df76e9ac83