### PR TITLE
Update docs CTA to open documentation

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -35,9 +35,15 @@ export function LandingPage({ onLaunch }: LandingPageProps) {
           <span>Tribe</span>
         </div>
         <div className="landing-nav-actions">
-          <button type="button" className="secondary-button">
+          <a
+            className="secondary-button"
+            href="https://docs.tribe.sh/"
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label="View Tribe documentation (opens in a new tab)"
+          >
             View docs
-          </button>
+          </a>
           <button type="button" className="primary-button" onClick={onLaunch}>
             Launch workspace
           </button>


### PR DESCRIPTION
## Summary
- replace the inert "View docs" button with an accessible link to the Tribe documentation

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_b_68e53c8d1e90832fa8e0e35da7ce84cf