### PR TITLE
Add material surface showcase to landing page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightIcon, Code2Icon, MessageCircleIcon, MonitorSmartphoneIcon, SparklesIcon } from 'lucide-react';
 import logoUrl from '../assets/star-of-david.svg';
+import { SurfaceShowcase } from './SurfaceShowcase';
 
 interface LandingPageProps {
   onLaunch: () => void;
@@ -278,6 +279,8 @@ export function LandingPage({ onLaunch }: LandingPageProps) {
             </div>
           </aside>
         </section>
+
+        <SurfaceShowcase />
 
         <section className="landing-anyone">
           <div className="landing-anyone-card">

--- a/src/components/SurfaceShowcase.tsx
+++ b/src/components/SurfaceShowcase.tsx
@@ -1,0 +1,139 @@
+import { type ReactNode } from 'react';
+
+interface SurfaceDefinition {
+  name: string;
+  description: string;
+  className: string;
+  example: ReactNode;
+}
+
+interface SurfaceCategory {
+  title: string;
+  subtitle: string;
+  surfaces: SurfaceDefinition[];
+}
+
+const surfaceCategories: SurfaceCategory[] = [
+  {
+    title: 'Surface',
+    subtitle: 'On the page.',
+    surfaces: [
+      {
+        name: 'Material Base',
+        description: 'Everyday use. Radius 6px.',
+        className: 'material-base',
+        example: 'Material Base\nTransparent max W [240px] h [100px]',
+      },
+      {
+        name: 'Material Small',
+        description: 'Slightly raised. Radius 6px.',
+        className: 'material-small',
+        example: 'Material Small\nTransparent max W [240px] h [100px]',
+      },
+      {
+        name: 'Material Medium',
+        description: 'Further raised. Radius 12px.',
+        className: 'material-medium',
+        example: 'Material Medium\nTransparent max W [240px] h [100px]',
+      },
+      {
+        name: 'Material Large',
+        description: 'Further raised. Radius 12px.',
+        className: 'material-large',
+        example: 'Material Large\nTransparent max W [240px] h [100px]',
+      },
+    ],
+  },
+  {
+    title: 'Floating',
+    subtitle: 'Above the page.',
+    surfaces: [
+      {
+        name: 'Material Tooltip',
+        description: 'Lightest shadow. Corner 6px. Tooltips will be the only floating element with a triangular stem.',
+        className: 'material-tooltip',
+        example: 'Material Tooltip\nTransparent max W [240px] h [100px]',
+      },
+      {
+        name: 'Material Menu',
+        description: 'Lift from page. Radius 12px.',
+        className: 'material-menu',
+        example: 'Material Menu\nTransparent max W [240px] h [100px]',
+      },
+      {
+        name: 'Material Modal',
+        description: 'Further lift. Radius 12px.',
+        className: 'material-modal',
+        example: 'Material Modal\nTransparent max W [240px] h [100px]',
+      },
+      {
+        name: 'Material Fullscreen',
+        description: 'Biggest lift. Radius 16px.',
+        className: 'material-fullscreen',
+        example: 'Material Fullscreen\nTransparent max W [240px] h [100px]',
+      },
+    ],
+  },
+];
+
+function formatExample(example: string): ReactNode {
+  const lines = example.split('\n');
+  return lines.map((line, index) => (
+    <span key={`${line}-${index}`}>
+      {line}
+      {index < lines.length - 1 ? <br /> : null}
+    </span>
+  ));
+}
+
+export function SurfaceShowcase(): JSX.Element {
+  return (
+    <section className="landing-surfaces" aria-labelledby="surface-heading">
+      <header>
+        <span className="landing-eyebrow">Surface tokens</span>
+        <h2 id="surface-heading">Material elevations for every context</h2>
+        <p>
+          Choose the elevation style that matches the intent of your element. These presets balance depth, accessibility, and
+          clarity for tooltips, menus, modals, and application chrome.
+        </p>
+      </header>
+
+      <div className="material-surface-grid">
+        {surfaceCategories.map((category) => (
+          <article key={category.title} className="material-surface-category">
+            <div>
+              <h3>{category.title}</h3>
+              <p>{category.subtitle}</p>
+            </div>
+            <div className="material-surface-table-wrapper">
+              <table className="material-surface-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Example</th>
+                    <th scope="col">Class name</th>
+                    <th scope="col">Usage</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {category.surfaces.map((surface) => (
+                    <tr key={surface.name}>
+                      <td>
+                        <div className={`material-surface-preview ${surface.className}`}>
+                          {formatExample(surface.example)}
+                        </div>
+                      </td>
+                      <td>
+                        <span className="material-class-badge">.{surface.className}</span>
+                      </td>
+                      <td className="material-surface-usage">{surface.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,6 +4,74 @@
   background-color: #f8fafc;
   line-height: 1.5;
   font-weight: 400;
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --primary: 240 5.9% 10%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 5.9% 90%;
+  --input: 240 5.9% 90%;
+  --ring: 240 10% 3.9%;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+  --radius: 0.5rem;
+  --sidebar-background: 0 0% 98%;
+  --sidebar-foreground: 240 5.3% 26.1%;
+  --sidebar-primary: 240 5.9% 10%;
+  --sidebar-primary-foreground: 0 0% 98%;
+  --sidebar-accent: 240 4.8% 95.9%;
+  --sidebar-accent-foreground: 240 5.9% 10%;
+  --sidebar-border: 220 13% 91%;
+  --sidebar-ring: 217.2 91.2% 59.8%;
+}
+
+.dark {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 240 10% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 240 4.9% 83.9%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+  --sidebar-background: 240 5.9% 10%;
+  --sidebar-foreground: 240 4.8% 95.9%;
+  --sidebar-primary: 224.3 76.3% 48%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 240 3.7% 15.9%;
+  --sidebar-accent-foreground: 240 4.8% 95.9%;
+  --sidebar-border: 240 3.7% 15.9%;
+  --sidebar-ring: 217.2 91.2% 59.8%;
 }
 
 * {
@@ -453,6 +521,207 @@ button {
   line-height: 1.8;
 }
 
+.landing-surfaces {
+  display: grid;
+  gap: 2.5rem;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: 32px;
+  padding: clamp(2rem, 3vw, 2.75rem);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+}
+
+.landing-surfaces header {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.landing-surfaces h2 {
+  margin: 0;
+  font-size: clamp(1.85rem, 3vw, 2.4rem);
+  color: #0f172a;
+}
+
+.landing-surfaces p {
+  margin: 0;
+  color: #334155;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.material-surface-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.material-surface-category {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.material-surface-category h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #0f172a;
+}
+
+.material-surface-category p {
+  margin: 0;
+  color: #475569;
+}
+
+.material-surface-table-wrapper {
+  overflow-x: auto;
+}
+
+.material-surface-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.material-surface-table thead th {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.material-surface-table tbody td {
+  padding: 1rem;
+  vertical-align: top;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.material-surface-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  height: 110px;
+  max-width: 240px;
+  min-width: 200px;
+  padding: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.material-class-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.08);
+  color: #4338ca;
+  font-weight: 600;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.material-surface-usage {
+  color: #475569;
+  line-height: 1.6;
+}
+
+.material-base {
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  box-shadow: 0 3px 8px rgba(15, 23, 42, 0.08);
+  border-radius: 6px;
+}
+
+.material-small {
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.12);
+  border-radius: 6px;
+}
+
+.material-medium {
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  border-radius: 12px;
+}
+
+.material-large {
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
+  border-radius: 12px;
+}
+
+.material-tooltip {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.18);
+  border-radius: 6px;
+  position: relative;
+}
+
+.material-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 8px 8px 0;
+  border-style: solid;
+  border-color: hsl(var(--popover)) transparent transparent;
+}
+
+.material-menu {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.22);
+  border-radius: 12px;
+}
+
+.material-modal {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.28);
+  border-radius: 12px;
+}
+
+.material-fullscreen {
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.32);
+  border-radius: 16px;
+}
+
+.dark .landing-surfaces {
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
+}
+
+.dark .landing-surfaces h2 {
+  color: #e2e8f0;
+}
+
+.dark .landing-surfaces p,
+.dark .material-surface-usage,
+.dark .material-surface-category p {
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.dark .material-surface-table thead th {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.dark .material-surface-table tbody td {
+  border-top-color: rgba(148, 163, 184, 0.24);
+}
+
+.dark .material-class-badge {
+  background: rgba(129, 140, 248, 0.16);
+  color: #c7d2fe;
+}
+
 .landing-design-grid {
   display: grid;
   gap: 1.5rem;
@@ -599,6 +868,10 @@ button {
   .landing-webcontainer-aside {
     order: -1;
   }
+
+  .material-surface-table {
+    min-width: 100%;
+  }
 }
 
 @media (max-width: 768px) {
@@ -645,6 +918,15 @@ button {
   .landing-anyone-card {
     padding: 2.25rem 1.75rem;
   }
+
+  .landing-surfaces {
+    padding: 1.75rem;
+    gap: 2rem;
+  }
+
+  .material-surface-table {
+    min-width: 420px;
+  }
 }
 
 @media (max-width: 520px) {
@@ -681,6 +963,10 @@ button {
 
   .landing-anyone-card h2 {
     font-size: 1.75rem;
+  }
+
+  .material-surface-table {
+    min-width: 360px;
   }
 }
 


### PR DESCRIPTION
## Summary
- define light and dark surface tokens to align material elevations
- create a reusable SurfaceShowcase component with usage guidance
- embed the showcase on the landing page with responsive styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e55a6ea4a8832f8262f69b190fc0cc