### PR TITLE
Refine AI chat handling with shared helper

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { createModelFactory } from '../../../server/lib/modelFactory';
+import { chatRequestSchema } from '../../../server/types';
+import {
+  generateAssistantResponse,
+  ModelResponseValidationError,
+} from '../../../server/lib/chat';
+
+const { modelFactory, warnings } = createModelFactory();
+warnings.forEach((warning) => console.warn(warning));
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  const headers = new Headers(init?.headers);
+  headers.set('content-type', 'application/json');
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!modelFactory) {
+    return jsonResponse({ error: 'AI provider not configured.' }, { status: 503 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+
+  const parseResult = chatRequestSchema.safeParse(payload);
+  if (!parseResult.success) {
+    return jsonResponse({ error: 'Invalid payload', details: parseResult.error.flatten() }, { status: 400 });
+  }
+
+  const requestPayload = parseResult.data;
+  const model = modelFactory();
+
+  try {
+    const assistantResponse = await generateAssistantResponse(model, requestPayload);
+    return jsonResponse(assistantResponse);
+  } catch (error) {
+    console.error('AI request failed', error);
+    if (error instanceof ModelResponseValidationError) {
+      return jsonResponse(
+        { error: 'Invalid model response structure', details: error.cause.flatten() },
+        { status: 500 }
+      );
+    }
+
+    if (error instanceof z.ZodError) {
+      return jsonResponse({ error: 'Schema validation error', details: error.flatten() }, { status: 500 });
+    }
+
+    return jsonResponse({ error: 'Failed to generate response' }, { status: 500 });
+  }
+}
+
+export function GET(): Response {
+  return jsonResponse({ error: 'Method not allowed' }, { status: 405 });
+}

--- a/server/lib/chat.ts
+++ b/server/lib/chat.ts
@@ -1,0 +1,39 @@
+import type { LanguageModel } from 'ai';
+import { convertToCoreMessages, generateObject } from 'ai';
+import { z } from 'zod';
+import {
+  assistantResponseSchema,
+  type AssistantResponse,
+  type ChatRequest,
+} from '../types';
+import { baseSystemPrompt } from './.server/llm/prompts';
+import { buildContextSummary } from './context';
+
+export class ModelResponseValidationError extends Error {
+  constructor(readonly cause: z.ZodError) {
+    super('Model response did not match the expected schema.');
+    this.name = 'ModelResponseValidationError';
+  }
+}
+
+export async function generateAssistantResponse(
+  model: LanguageModel,
+  request: ChatRequest
+): Promise<AssistantResponse> {
+  const { object } = await generateObject({
+    model,
+    temperature: 0.2,
+    schema: assistantResponseSchema,
+    system: baseSystemPrompt,
+    messages: convertToCoreMessages(request.messages),
+    prompt: `${buildContextSummary(request)}\n\nUser request:\n${request.userMessage}`,
+  });
+
+  const parseResult = assistantResponseSchema.safeParse(object);
+
+  if (!parseResult.success) {
+    throw new ModelResponseValidationError(parseResult.error);
+  }
+
+  return parseResult.data;
+}

--- a/server/lib/context.ts
+++ b/server/lib/context.ts
@@ -1,0 +1,17 @@
+import type { ChatRequest } from '../types';
+
+export function buildContextSummary(request: ChatRequest): string {
+  const dependencyList = request.projectSummary.dependencies.length
+    ? request.projectSummary.dependencies.join(', ')
+    : 'No dependencies installed yet.';
+
+  const fileSummary = request.projectSummary.files
+    .slice(0, 20)
+    .map((file) => {
+      const preview = file.preview.replace(/```/g, '');
+      return `• ${file.path} (${file.size} chars)\n${preview}`;
+    })
+    .join('\n\n');
+
+  return `Current dependencies: ${dependencyList}\n\nImportant files:\n${fileSummary || 'No project files yet.'}`;
+}

--- a/server/lib/modelFactory.ts
+++ b/server/lib/modelFactory.ts
@@ -1,0 +1,77 @@
+import type { LanguageModel } from 'ai';
+import { createCohere } from '@ai-sdk/cohere';
+import { createGeminiProvider } from 'ai-sdk-provider-gemini-cli';
+import { createGroq } from '@ai-sdk/groq';
+
+export type GeminiAuthType = 'oauth-personal' | 'api-key' | 'gemini-api-key';
+export type ProviderName = 'gemini' | 'groq' | 'cohere';
+
+export interface ModelFactoryResult {
+  modelFactory: (() => LanguageModel) | null;
+  providerName: ProviderName;
+  warnings: string[];
+}
+
+export function createModelFactory(): ModelFactoryResult {
+  const providerNameEnv = process.env.AI_PROVIDER;
+  const providerName: ProviderName =
+    providerNameEnv === 'groq' || providerNameEnv === 'cohere' ? providerNameEnv : 'gemini';
+
+  const warnings: string[] = [];
+  let modelFactory: (() => LanguageModel) | null = null;
+
+  if (providerName === 'groq') {
+    const groqApiKey = process.env.GROQ_API_KEY;
+    const groqModelName = process.env.GROQ_MODEL ?? 'deepseek-r1-distill-llama-70b';
+
+    if (!groqApiKey) {
+      warnings.push('Missing GROQ_API_KEY environment variable. Configure GROQ_API_KEY to enable Groq responses.');
+    } else {
+      const groqProvider = createGroq({ apiKey: groqApiKey });
+      modelFactory = () => groqProvider(groqModelName) as unknown as LanguageModel;
+    }
+
+    return { modelFactory, providerName, warnings };
+  }
+
+  if (providerName === 'cohere') {
+    const cohereApiKey = process.env.COHERE_API_KEY;
+    const cohereModelName = process.env.COHERE_MODEL ?? 'command-r-plus';
+
+    if (!cohereApiKey) {
+      warnings.push('Missing COHERE_API_KEY environment variable. Configure COHERE_API_KEY to enable Cohere responses.');
+    } else {
+      const cohereProvider = createCohere({ apiKey: cohereApiKey });
+      modelFactory = () => cohereProvider(cohereModelName) as unknown as LanguageModel;
+    }
+
+    return { modelFactory, providerName, warnings };
+  }
+
+  const geminiAuthTypeEnv = process.env.GEMINI_AUTH_TYPE as GeminiAuthType | undefined;
+  const geminiApiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+  const geminiAuthType: GeminiAuthType = geminiAuthTypeEnv ?? (geminiApiKey ? 'api-key' : 'oauth-personal');
+  const missingGeminiApiKey = geminiAuthType !== 'oauth-personal' && !geminiApiKey;
+
+  if (missingGeminiApiKey) {
+    warnings.push(
+      'Missing GEMINI_API_KEY environment variable. Configure GEMINI_API_KEY or switch GEMINI_AUTH_TYPE to "oauth-personal" to enable AI features.'
+    );
+  }
+
+  const gemini = !missingGeminiApiKey
+    ? createGeminiProvider(
+        geminiAuthType === 'oauth-personal'
+          ? { authType: 'oauth-personal' }
+          : { authType: geminiAuthType, apiKey: geminiApiKey as string }
+      )
+    : null;
+
+  const geminiModelName = process.env.GEMINI_MODEL ?? 'gemini-2.5-flash';
+
+  if (gemini) {
+    modelFactory = () => gemini(geminiModelName) as unknown as LanguageModel;
+  }
+
+  return { modelFactory, providerName, warnings };
+}


### PR DESCRIPTION
## Summary
- add a shared helper that calls `generateObject` and validates structured AI responses in one place
- update the Express chat endpoint to reuse the shared helper and surface schema validation errors consistently
- update the Next.js-style route handler to consume the shared helper for parity with the Express endpoint

## Testing
- npm run lint
- npm run build:server

------
https://chatgpt.com/codex/tasks/task_b_68e5b357ed84832e8d3d43686120b557