### PR TITLE
Refactor ai components to share class name helper

### DIFF
--- a/src/components/ai-elements/actions.tsx
+++ b/src/components/ai-elements/actions.tsx
@@ -1,8 +1,5 @@
 import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 export interface ActionsProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;

--- a/src/components/ai-elements/artifact.tsx
+++ b/src/components/ai-elements/artifact.tsx
@@ -1,10 +1,7 @@
 import type { ComponentProps, HTMLAttributes } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 export function Artifact({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('artifact', className)} {...props} />;

--- a/src/components/ai-elements/connection.tsx
+++ b/src/components/ai-elements/connection.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from 'react';
+import { cn } from '@/utils/cn';
 
 type ConnectionProps = {
   fromX: number;
@@ -7,10 +8,6 @@ type ConnectionProps = {
   toY: number;
   className?: string;
 };
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
 
 const clamp = (value: number, min: number, max: number) => {
   return Math.min(Math.max(value, min), max);

--- a/src/components/ai-elements/controls.tsx
+++ b/src/components/ai-elements/controls.tsx
@@ -1,9 +1,6 @@
 import type { ComponentProps } from 'react';
 import { Controls as ReactFlowControls } from '@xyflow/react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 export type ControlsProps = ComponentProps<typeof ReactFlowControls> & {
   className?: string;

--- a/src/components/ai-elements/edge.tsx
+++ b/src/components/ai-elements/edge.tsx
@@ -7,10 +7,7 @@ import {
   getBezierPath,
   type EdgeProps,
 } from '@xyflow/react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 function useBezierPath(props: EdgeProps) {
   const { sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition } = props;

--- a/src/components/ai-elements/node.tsx
+++ b/src/components/ai-elements/node.tsx
@@ -1,9 +1,6 @@
 import type { ComponentProps } from 'react';
 import { Handle, Position } from '@xyflow/react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 export interface NodeProps extends ComponentProps<'div'> {
   handles: {

--- a/src/components/ai-elements/panel.tsx
+++ b/src/components/ai-elements/panel.tsx
@@ -1,9 +1,6 @@
 import type { ComponentProps } from 'react';
 import { Panel as ReactFlowPanel } from '@xyflow/react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 export type PanelPosition =
   | 'top-left'

--- a/src/components/ai-elements/toolbar.tsx
+++ b/src/components/ai-elements/toolbar.tsx
@@ -1,9 +1,6 @@
 import type { ComponentProps } from 'react';
 import { NodeToolbar } from '@xyflow/react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 export type ToolbarProps = ComponentProps<typeof NodeToolbar>;
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,9 +1,6 @@
 import { forwardRef } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
-
-function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '@/utils/cn';
 
 const variantClassNames = {
   default: 'ui-button-default',

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add a shared `cn` utility for composing class names
- update ai-elements and button components to import the shared helper

## Testing
- npm run lint *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_68e5bc848658832ea6dab032a6b38053