### PR TITLE
feat: scaffold agent type system

### DIFF
--- a/server/types.ts
+++ b/server/types.ts
@@ -1,4 +1,12 @@
 import { z } from 'zod';
+import { chatMessageSchema as clientChatMessageSchema } from '../src/types/messages';
+import {
+  workspaceStateSchema,
+  workspaceOperationSchema,
+  workspaceSnapshotSchema,
+  workspaceEntrySchema,
+} from '../src/types/workspace';
+import { toolInvocationSchema, toolResultSchema } from '../src/types/tools';
 
 export const assistantActionSchema = z.discriminatedUnion('type', [
   z.object({
@@ -20,13 +28,14 @@ export const assistantActionSchema = z.discriminatedUnion('type', [
 export const assistantResponseSchema = z.object({
   reply: z.string(),
   actions: z.array(assistantActionSchema).default([]),
+  toolCalls: z.array(toolInvocationSchema).optional(),
+  toolResults: z.array(toolResultSchema).optional(),
 });
 
 export type AssistantAction = z.infer<typeof assistantActionSchema>;
 export type AssistantResponse = z.infer<typeof assistantResponseSchema>;
 
-export const chatMessageSchema = z.object({
-  role: z.enum(['user', 'assistant', 'system']),
+export const chatMessageSchema = clientChatMessageSchema.pick({ role: true }).extend({
   content: z.string(),
 });
 
@@ -44,6 +53,11 @@ export const chatRequestSchema = z.object({
     dependencies: z.array(z.string()),
   }),
   userMessage: z.string(),
+  mode: z.string().optional(),
+  workspaceState: workspaceStateSchema.optional(),
+  recentOperations: z.array(workspaceOperationSchema).optional(),
+  recentSnapshots: z.array(workspaceSnapshotSchema).optional(),
+  entries: z.array(workspaceEntrySchema).optional(),
 });
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,15 @@
-export type ChatRole = 'user' | 'assistant' | 'system';
+import type { AgentRole } from '../types/messages';
+import type {
+  WorkspaceEntry,
+  WorkspaceState,
+  WorkspaceOperation,
+  WorkspaceSnapshot,
+  WorkspaceFile,
+  WorkspaceDirectory,
+} from '../types/workspace';
+import type { ToolInvocation, ToolResult } from '../types/tools';
+
+export type ChatRole = Extract<AgentRole, 'user' | 'assistant' | 'system'>;
 
 export interface ChatMessage {
   id: string;
@@ -6,23 +17,13 @@ export interface ChatMessage {
   content: string;
   actions?: ActionResult[];
   error?: string;
+  createdAt?: number;
+  metadata?: Record<string, string | number | boolean>;
 }
 
-export type FileNode = {
-  type: 'file';
-  path: string;
-  name: string;
-  content: string;
-};
-
-export type DirectoryNode = {
-  type: 'directory';
-  path: string;
-  name: string;
-  children: Array<FileNode | DirectoryNode>;
-};
-
-export type ProjectTree = DirectoryNode;
+export type FileNode = WorkspaceFile;
+export type DirectoryNode = WorkspaceDirectory;
+export type ProjectTree = WorkspaceDirectory;
 
 export type ActionResult =
   | {
@@ -50,6 +51,8 @@ export type ActionResult =
 export interface AiActionResponse {
   reply: string;
   actions: ActionResult[];
+  toolCalls?: ToolInvocation[];
+  toolResults?: ToolResult[];
 }
 
 export interface FileSummary {
@@ -66,4 +69,16 @@ export interface ChatRequestPayload {
     dependencies: string[];
   };
   userMessage: string;
+  mode?: string;
 }
+
+export type {
+  WorkspaceEntry,
+  WorkspaceState,
+  WorkspaceOperation,
+  WorkspaceSnapshot,
+  WorkspaceFile,
+  WorkspaceDirectory,
+  ToolInvocation,
+  ToolResult,
+};

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,0 +1,168 @@
+import { z } from 'zod';
+
+export const agentModes = ['fast', 'balanced', 'deep'] as const;
+export type AgentMode = (typeof agentModes)[number];
+
+export const thinkingBudgets = {
+  fast: 0,
+  balanced: 2048,
+  deep: 8192,
+} as const satisfies Record<AgentMode, number>;
+
+export const geminiModels = {
+  fast: 'gemini-2.0-flash',
+  balanced: 'gemini-2.0-flash-thinking-exp',
+  deep: 'gemini-2.5-pro-exp',
+} as const satisfies Record<AgentMode, string>;
+
+export interface AgentMetadata {
+  id: string;
+  label: string;
+  description: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ModelConfig {
+  provider: 'gemini';
+  model: string;
+  maxOutputTokens: number;
+  thinkingBudget: number;
+  temperature: number;
+}
+
+export interface AgentRuntimeConfig {
+  maxToolIterations: number;
+  enablePlanning: boolean;
+  allowParallelTools: boolean;
+  maxParallelTools: number;
+}
+
+export interface AgentConfiguration {
+  mode: AgentMode;
+  metadata: AgentMetadata;
+  systemPrompt: string;
+  model: ModelConfig;
+  runtime: AgentRuntimeConfig;
+}
+
+export const agentConfigurationSchema = z.object({
+  mode: z.enum(agentModes),
+  metadata: z.object({
+    id: z.string(),
+    label: z.string(),
+    description: z.string(),
+    createdAt: z.number(),
+    updatedAt: z.number(),
+  }),
+  systemPrompt: z.string(),
+  model: z.object({
+    provider: z.literal('gemini'),
+    model: z.string(),
+    maxOutputTokens: z.number().int().positive(),
+    thinkingBudget: z.number().int().min(0),
+    temperature: z.number().min(0).max(2),
+  }),
+  runtime: z.object({
+    maxToolIterations: z.number().int().positive(),
+    enablePlanning: z.boolean(),
+    allowParallelTools: z.boolean(),
+    maxParallelTools: z.number().int().positive(),
+  }),
+});
+
+export type AgentConfigurationInput = z.input<typeof agentConfigurationSchema>;
+
+export function createAgentConfiguration(
+  mode: AgentMode,
+  overrides: Partial<Omit<AgentConfiguration, 'mode'>> = {},
+): AgentConfiguration {
+  const now = Date.now();
+  const defaults: AgentConfiguration = {
+    mode,
+    metadata: {
+      id: `agent-${mode}`,
+      label: mode === 'fast' ? 'Fast' : mode === 'balanced' ? 'Balanced' : 'Deep',
+      description:
+        mode === 'fast'
+          ? 'Rapid responses with minimal reasoning tokens.'
+          : mode === 'balanced'
+            ? 'Balanced depth with moderate reasoning budget.'
+            : 'Deep reasoning with the highest thinking budget.',
+      createdAt: now,
+      updatedAt: now,
+    },
+    systemPrompt: '',
+    model: {
+      provider: 'gemini',
+      model: geminiModels[mode],
+      maxOutputTokens: mode === 'deep' ? 4096 : 2048,
+      thinkingBudget: thinkingBudgets[mode],
+      temperature: mode === 'fast' ? 0.6 : mode === 'balanced' ? 0.8 : 0.9,
+    },
+    runtime: {
+      maxToolIterations: mode === 'deep' ? 12 : mode === 'balanced' ? 8 : 4,
+      enablePlanning: mode !== 'fast',
+      allowParallelTools: mode !== 'deep',
+      maxParallelTools: mode === 'fast' ? 3 : mode === 'balanced' ? 2 : 1,
+    },
+  };
+
+  const merged: AgentConfiguration = {
+    ...defaults,
+    ...overrides,
+    metadata: { ...defaults.metadata, ...overrides.metadata },
+    model: { ...defaults.model, ...overrides.model },
+    runtime: { ...defaults.runtime, ...overrides.runtime },
+  };
+
+  const parsed = agentConfigurationSchema.parse(merged);
+  return parsed;
+}
+
+export interface WorkspaceContext {
+  id: string;
+  name: string;
+  summary: string;
+  activeFilePath?: string;
+  repositoryUrl?: string;
+  pendingOperations: number;
+}
+
+export function buildSystemPrompt(
+  mode: AgentMode,
+  context: WorkspaceContext,
+  additionalDirectives: string[] = [],
+): string {
+  const baseDirectives: string[] = [
+    'You are a coding agent operating inside a browser-based WebContainer.',
+    'Always follow WCAG 2.1 AA accessibility standards.',
+    'Prefer secure defaults and sanitize all user-controlled inputs.',
+    `Current workspace summary: ${context.summary}`,
+  ];
+
+  if (context.activeFilePath) {
+    baseDirectives.push(`Active file: ${context.activeFilePath}`);
+  }
+
+  if (context.repositoryUrl) {
+    baseDirectives.push(`Repository: ${context.repositoryUrl}`);
+  }
+
+  if (context.pendingOperations > 0) {
+    baseDirectives.push(
+      `There are ${context.pendingOperations} pending workspace operations. Account for potential conflicts before editing files.`,
+    );
+  }
+
+  const reasoningDirective =
+    mode === 'fast'
+      ? 'Use minimal reasoning tokens. Prioritize actionable answers.'
+      : mode === 'balanced'
+        ? 'Balance reasoning depth with responsiveness. Use planning when helpful.'
+        : 'Use deep reasoning and planning to craft thorough solutions.';
+
+  baseDirectives.push(reasoningDirective);
+
+  return [...baseDirectives, ...additionalDirectives].join('\n');
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import { ToolInvocation, toolInvocationSchema, ToolResult, toolResultSchema } from './tools';
+
+export const agentRoles = ['system', 'user', 'assistant', 'tool'] as const;
+export type AgentRole = (typeof agentRoles)[number];
+
+export interface BaseMessage {
+  id: string;
+  role: AgentRole;
+  createdAt: number;
+}
+
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ErrorContent {
+  type: 'error';
+  message: string;
+}
+
+export interface ReasoningTraceContent {
+  type: 'reasoning-trace';
+  steps: string[];
+}
+
+export type AssistantContent = TextContent | ErrorContent | ReasoningTraceContent;
+
+export interface AssistantMessage extends BaseMessage {
+  role: 'assistant';
+  content: AssistantContent[];
+  toolCalls?: ToolInvocation[];
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface UserMessage extends BaseMessage {
+  role: 'user';
+  content: TextContent[];
+  mode: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface SystemMessage extends BaseMessage {
+  role: 'system';
+  content: TextContent[];
+}
+
+export interface ToolMessage extends BaseMessage {
+  role: 'tool';
+  content: TextContent[];
+  toolResult: ToolResult;
+}
+
+export type AgentMessage = AssistantMessage | UserMessage | SystemMessage | ToolMessage;
+
+export const textContentSchema: z.ZodType<TextContent> = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+
+export const errorContentSchema: z.ZodType<ErrorContent> = z.object({
+  type: z.literal('error'),
+  message: z.string(),
+});
+
+export const reasoningTraceContentSchema: z.ZodType<ReasoningTraceContent> = z.object({
+  type: z.literal('reasoning-trace'),
+  steps: z.array(z.string()),
+});
+
+export const assistantContentSchema: z.ZodType<AssistantContent> = z.union([
+  textContentSchema,
+  errorContentSchema,
+  reasoningTraceContentSchema,
+]);
+
+export const baseMessageSchema: z.ZodType<BaseMessage> = z.object({
+  id: z.string(),
+  role: z.enum(agentRoles),
+  createdAt: z.number().int(),
+});
+
+export const assistantMessageSchema: z.ZodType<AssistantMessage> = baseMessageSchema.extend({
+  role: z.literal('assistant'),
+  content: z.array(assistantContentSchema),
+  toolCalls: z.array(toolInvocationSchema).optional(),
+  metadata: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+});
+
+export const userMessageSchema: z.ZodType<UserMessage> = baseMessageSchema.extend({
+  role: z.literal('user'),
+  content: z.array(textContentSchema),
+  mode: z.string(),
+  metadata: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+});
+
+export const systemMessageSchema: z.ZodType<SystemMessage> = baseMessageSchema.extend({
+  role: z.literal('system'),
+  content: z.array(textContentSchema),
+});
+
+export const toolMessageSchema: z.ZodType<ToolMessage> = baseMessageSchema.extend({
+  role: z.literal('tool'),
+  content: z.array(textContentSchema),
+  toolResult: toolResultSchema,
+});
+
+export const agentMessageSchema: z.ZodType<AgentMessage> = z.discriminatedUnion('role', [
+  assistantMessageSchema,
+  userMessageSchema,
+  systemMessageSchema,
+  toolMessageSchema,
+]);
+
+export const chatMessageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['system', 'user', 'assistant']),
+  content: z.string(),
+  createdAt: z.number().int().optional(),
+  metadata: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+});

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+
+export const toolKinds = ['fs', 'shell', 'npm', 'planning', 'workspace', 'terminal'] as const;
+export type ToolKind = (typeof toolKinds)[number];
+
+export const toolExecutionStatus = ['idle', 'running', 'succeeded', 'failed'] as const;
+export type ToolExecutionStatus = (typeof toolExecutionStatus)[number];
+
+export interface ToolDefinition<TInput extends z.ZodTypeAny, TResult extends z.ZodTypeAny> {
+  name: string;
+  description: string;
+  kind: ToolKind;
+  parameters: TInput;
+  result: TResult;
+  timeoutMs?: number;
+  maxAttempts?: number;
+}
+
+export interface ToolRegistryEntry<TInput extends z.ZodTypeAny, TResult extends z.ZodTypeAny>
+  extends ToolDefinition<TInput, TResult> {
+  version: string;
+  enabled: boolean;
+}
+
+export const toolInvocationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  args: z.unknown(),
+  attempt: z.number().int().min(1),
+});
+
+export type ToolInvocation = z.infer<typeof toolInvocationSchema>;
+
+export const toolResultSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(toolExecutionStatus),
+  output: z.unknown().optional(),
+  error: z.string().optional(),
+  startedAt: z.number().int(),
+  completedAt: z.number().int().optional(),
+});
+
+export type ToolResult = z.infer<typeof toolResultSchema>;
+
+export interface BroadcastChannelMessage<TPayload> {
+  channel: string;
+  requestId: string;
+  payload: TPayload;
+}
+
+export interface ToolBridgeRequest {
+  invocation: ToolInvocation;
+  createdAt: number;
+}
+
+export interface ToolBridgeResponse {
+  result: ToolResult;
+  rawOutput?: string;
+}
+
+export interface ToolRetryConfig {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  factor: number;
+}
+
+export const defaultToolRetryConfig: ToolRetryConfig = {
+  maxAttempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 2000,
+  factor: 2,
+};
+
+export type ToolExecutionRecord = {
+  invocation: ToolInvocation;
+  status: ToolExecutionStatus;
+  attempts: number;
+  lastError?: string;
+  lastAttemptAt?: number;
+};
+
+export function getNextRetryDelay(attempt: number, config: ToolRetryConfig = defaultToolRetryConfig): number {
+  const delay = config.baseDelayMs * Math.pow(config.factor, attempt - 1);
+  return Math.min(delay, config.maxDelayMs);
+}
+
+export type ToolExecutor<TInput extends z.ZodTypeAny, TResult extends z.ZodTypeAny> = (
+  input: z.infer<TInput>,
+) => Promise<z.infer<TResult>>;

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,0 +1,184 @@
+import { z } from 'zod';
+
+export type WorkspaceFileKind = 'file' | 'directory';
+
+export interface WorkspaceFileBase {
+  path: string;
+  name: string;
+  lastModified: number;
+}
+
+export interface WorkspaceFile extends WorkspaceFileBase {
+  kind: 'file';
+  language: string;
+  content: string;
+  size: number;
+}
+
+export interface WorkspaceDirectory extends WorkspaceFileBase {
+  kind: 'directory';
+  children: WorkspaceEntry[];
+}
+
+export type WorkspaceEntry = WorkspaceFile | WorkspaceDirectory;
+
+export interface WorkspaceSnapshot {
+  id: string;
+  createdAt: number;
+  entries: WorkspaceEntry[];
+  activePath?: string;
+  openPaths: string[];
+}
+
+export type WorkspaceOperationType =
+  | 'create-file'
+  | 'update-file'
+  | 'delete-path'
+  | 'rename-path'
+  | 'run-command';
+
+export interface WorkspaceOperationBase {
+  id: string;
+  type: WorkspaceOperationType;
+  createdAt: number;
+  updatedAt: number;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  error?: string;
+}
+
+export interface CreateOrUpdateFileOperation extends WorkspaceOperationBase {
+  type: 'create-file' | 'update-file';
+  path: string;
+  content: string;
+  language: string;
+}
+
+export interface DeletePathOperation extends WorkspaceOperationBase {
+  type: 'delete-path';
+  path: string;
+}
+
+export interface RenamePathOperation extends WorkspaceOperationBase {
+  type: 'rename-path';
+  from: string;
+  to: string;
+}
+
+export interface RunCommandOperation extends WorkspaceOperationBase {
+  type: 'run-command';
+  command: string;
+  cwd: string;
+  output: string[];
+}
+
+export type WorkspaceOperation =
+  | CreateOrUpdateFileOperation
+  | DeletePathOperation
+  | RenamePathOperation
+  | RunCommandOperation;
+
+export interface WorkspaceState {
+  id: string;
+  name: string;
+  version: number;
+  snapshot: WorkspaceSnapshot;
+  operations: WorkspaceOperation[];
+  pendingSave: boolean;
+}
+
+export const workspaceFileSchema: z.ZodType<WorkspaceFile> = z.object({
+  kind: z.literal('file'),
+  path: z.string(),
+  name: z.string(),
+  lastModified: z.number().int(),
+  language: z.string(),
+  content: z.string(),
+  size: z.number().int().nonnegative(),
+});
+
+export const workspaceDirectorySchema: z.ZodType<WorkspaceDirectory> = z.lazy(() =>
+  z.object({
+    kind: z.literal('directory'),
+    path: z.string(),
+    name: z.string(),
+    lastModified: z.number().int(),
+    children: z.array(workspaceEntrySchema),
+  }),
+);
+
+export const workspaceEntrySchema: z.ZodType<WorkspaceEntry> = z.union([
+  workspaceFileSchema,
+  workspaceDirectorySchema,
+]);
+
+export const workspaceSnapshotSchema: z.ZodType<WorkspaceSnapshot> = z.object({
+  id: z.string(),
+  createdAt: z.number().int(),
+  entries: z.array(workspaceEntrySchema),
+  activePath: z.string().optional(),
+  openPaths: z.array(z.string()),
+});
+
+export const workspaceOperationSchema: z.ZodType<WorkspaceOperation> = z.discriminatedUnion('type', [
+  z.object({
+    id: z.string(),
+    type: z.literal('create-file'),
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+    status: z.enum(['pending', 'running', 'completed', 'failed']),
+    error: z.string().optional(),
+    path: z.string(),
+    content: z.string(),
+    language: z.string(),
+  }),
+  z.object({
+    id: z.string(),
+    type: z.literal('update-file'),
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+    status: z.enum(['pending', 'running', 'completed', 'failed']),
+    error: z.string().optional(),
+    path: z.string(),
+    content: z.string(),
+    language: z.string(),
+  }),
+  z.object({
+    id: z.string(),
+    type: z.literal('delete-path'),
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+    status: z.enum(['pending', 'running', 'completed', 'failed']),
+    error: z.string().optional(),
+    path: z.string(),
+  }),
+  z.object({
+    id: z.string(),
+    type: z.literal('rename-path'),
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+    status: z.enum(['pending', 'running', 'completed', 'failed']),
+    error: z.string().optional(),
+    from: z.string(),
+    to: z.string(),
+  }),
+  z.object({
+    id: z.string(),
+    type: z.literal('run-command'),
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+    status: z.enum(['pending', 'running', 'completed', 'failed']),
+    error: z.string().optional(),
+    command: z.string(),
+    cwd: z.string(),
+    output: z.array(z.string()),
+  }),
+]);
+
+export const workspaceStateSchema: z.ZodType<WorkspaceState> = z.object({
+  id: z.string(),
+  name: z.string(),
+  version: z.number().int().nonnegative(),
+  snapshot: workspaceSnapshotSchema,
+  operations: z.array(workspaceOperationSchema),
+  pendingSave: z.boolean(),
+});


### PR DESCRIPTION
## Summary
- introduce dedicated agent, workspace, tool, and message type modules with strict Zod schemas
- update shared client and server type utilities to reuse the new schema primitives
- expose helper utilities for building agent configurations and retry policies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e5c8bdcbf8832fad958b6585096d59